### PR TITLE
[Feature] Split date pickers

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-<<<<<<< HEAD
-"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
-"PO-Revision-Date: 2020-06-02T05:19:33.233Z\n"
-=======
 "POT-Creation-Date: 2020-06-02T14:22:35.930Z\n"
 "PO-Revision-Date: 2020-06-02T14:22:35.930Z\n"
->>>>>>> development
 
 msgid "Template not loaded"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-06-01T17:25:41.393Z\n"
-"PO-Revision-Date: 2020-06-01T17:25:41.393Z\n"
+"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
+"PO-Revision-Date: 2020-06-02T05:19:33.233Z\n"
 
 msgid "Template not loaded"
 msgstr ""
@@ -83,10 +83,10 @@ msgstr ""
 msgid "Select element to export..."
 msgstr ""
 
-msgid "Start date"
+msgid "Start period"
 msgstr ""
 
-msgid "End date"
+msgid "End period"
 msgstr ""
 
 msgid "Organisation units"
@@ -111,6 +111,12 @@ msgid "No theme"
 msgstr ""
 
 msgid "Populate template with data"
+msgstr ""
+
+msgid "Start date"
+msgstr ""
+
+msgid "End date"
 msgstr ""
 
 msgid "Edit theme"
@@ -207,7 +213,10 @@ msgstr ""
 msgid "You need to select at least one element to export"
 msgstr ""
 
-msgid "You need to select start and end dates for dataSet templates"
+msgid "You need to select start and end periods for dataSet templates"
+msgstr ""
+
+msgid "You need to select start and end dates to populate template"
 msgstr ""
 
 msgid "Downloading template..."

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,11 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-<<<<<<< HEAD
-"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
-=======
 "POT-Creation-Date: 2020-06-02T14:22:35.930Z\n"
->>>>>>> development
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-06-01T17:25:41.393Z\n"
+"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -85,11 +85,11 @@ msgstr "Modelo de Datos"
 msgid "Select element to export..."
 msgstr "Seleccione elemento a exportar..."
 
-msgid "Start date"
-msgstr "Fecha inicial"
+msgid "Start period"
+msgstr "Periodo inicial"
 
-msgid "End date"
-msgstr "Fecha final"
+msgid "End period"
+msgstr "Periodo final"
 
 msgid "Organisation units"
 msgstr "Unidades Organizativas"
@@ -114,6 +114,12 @@ msgstr "Sin tema"
 
 msgid "Populate template with data"
 msgstr "Rellenar plantilla con datos"
+
+msgid "Start date"
+msgstr "Fecha inicial"
+
+msgid "End date"
+msgstr "Fecha final"
 
 msgid "Edit theme"
 msgstr "Editar tema"
@@ -211,8 +217,11 @@ msgstr ""
 msgid "You need to select at least one element to export"
 msgstr "Seleccione al menos un elemento a exportar"
 
-msgid "You need to select start and end dates for dataSet templates"
-msgstr "Seleccione fecha de inicio y de fin"
+msgid "You need to select start and end periods for dataSet templates"
+msgstr "Seleccione periodos de inicio y de fin para plantillas de tipo dataSet"
+
+msgid "You need to select start and end dates to populate template"
+msgstr "Seleccione fecha de inicio y de fin para rellenar la plantilla"
 
 msgid "Downloading template..."
 msgstr "Descargando plantilla..."

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,11 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-<<<<<<< HEAD
-"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
-=======
 "POT-Creation-Date: 2020-06-02T14:22:35.930Z\n"
->>>>>>> development
 "PO-Revision-Date: 2019-10-10T10:41:21.864Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-06-01T17:25:41.393Z\n"
+"POT-Creation-Date: 2020-06-02T05:19:33.233Z\n"
 "PO-Revision-Date: 2019-10-10T10:41:21.864Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -83,10 +83,10 @@ msgstr ""
 msgid "Select element to export..."
 msgstr ""
 
-msgid "Start date"
+msgid "Start period"
 msgstr ""
 
-msgid "End date"
+msgid "End period"
 msgstr ""
 
 msgid "Organisation units"
@@ -111,6 +111,12 @@ msgid "No theme"
 msgstr ""
 
 msgid "Populate template with data"
+msgstr ""
+
+msgid "Start date"
+msgstr ""
+
+msgid "End date"
 msgstr ""
 
 msgid "Edit theme"
@@ -207,7 +213,10 @@ msgstr ""
 msgid "You need to select at least one element to export"
 msgstr ""
 
-msgid "You need to select start and end dates for dataSet templates"
+msgid "You need to select start and end periods for dataSet templates"
+msgstr ""
+
+msgid "You need to select start and end dates to populate template"
 msgstr ""
 
 msgid "Downloading template..."

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -8,16 +8,17 @@ import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
 import { TemplateRepository } from "../repositories/TemplateRepository";
 
-interface DownloadTemplateProps {
-    api: unknown;
+export interface DownloadTemplateProps {
     type: DataFormType;
-    id: string;
+    id: Id;
+    language: string;
     orgUnits?: string[];
-    populate: boolean;
+    theme?: Id;
     startDate?: Moment;
     endDate?: Moment;
-    language?: string;
-    theme?: Id;
+    populate: boolean;
+    populateStartDate?: Moment;
+    populateEndDate?: Moment;
 }
 
 export class DownloadTemplateUseCase {
@@ -27,17 +28,21 @@ export class DownloadTemplateUseCase {
         private excelRepository: ExcelRepository
     ) {}
 
-    public async execute({
-        api,
-        type,
-        id,
-        theme: themeId,
-        orgUnits = [],
-        populate,
-        startDate,
-        endDate,
-        language,
-    }: DownloadTemplateProps): Promise<void> {
+    public async execute(
+        api: unknown,
+        {
+            type,
+            id,
+            theme: themeId,
+            orgUnits = [],
+            startDate,
+            endDate,
+            language,
+            populate,
+            populateStartDate,
+            populateEndDate,
+        }: DownloadTemplateProps
+    ): Promise<void> {
         try {
             const templateId = type === "dataSets" ? dataSetId : programId;
             const template = this.templateRepository.getTemplate(templateId);
@@ -67,13 +72,13 @@ export class DownloadTemplateUseCase {
 
             if (theme) await this.excelRepository.applyTheme(template, theme);
 
-            if (populate) {
+            if (populate && populateStartDate && populateEndDate) {
                 const dataPackage = await this.instance.getDataPackage({
                     type,
                     id,
                     orgUnits,
-                    startDate,
-                    endDate,
+                    startDate: populateStartDate,
+                    endDate: populateEndDate,
                 });
                 await this.excelRepository.populateTemplate(template, dataPackage);
             }

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -335,7 +335,11 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                             label={i18n.t("Start date")}
                             value={state.populateStartDate ?? null}
                             onChange={(date: Date) => onStartDateChange("populateStartDate", date)}
-                            minDate={state.type === "dataSets" ? state.startDate : undefined}
+                            minDate={
+                                state.type === "dataSets"
+                                    ? state.startDate?.startOf(datePickerFormat?.unit ?? "day")
+                                    : undefined
+                            }
                             maxDate={moment.min(
                                 _.compact([
                                     state.type === "dataSets" && state.endDate,
@@ -359,7 +363,11 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                                     state.populateStartDate,
                                 ])
                             )}
-                            maxDate={state.type === "dataSets" ? state.endDate : undefined}
+                            maxDate={
+                                state.type === "dataSets"
+                                    ? state.endDate?.endOf(datePickerFormat?.unit ?? "day")
+                                    : undefined
+                            }
                             views={datePickerFormat?.views}
                             format={datePickerFormat?.format}
                             InputLabelProps={{ style: { color: "#494949" } }}

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -1,11 +1,12 @@
 import { Checkbox, FormControlLabel, makeStyles } from "@material-ui/core";
 import { DatePicker, OrgUnitsSelector } from "d2-ui-components";
 import _ from "lodash";
-import moment, { Moment } from "moment";
-import React, { useEffect, useState, useMemo } from "react";
+import moment from "moment";
+import React, { useEffect, useMemo, useState } from "react";
 import { CompositionRoot } from "../../../CompositionRoot";
 import { DataForm, DataFormType } from "../../../domain/entities/DataForm";
 import { Theme } from "../../../domain/entities/Theme";
+import { DownloadTemplateProps } from "../../../domain/usecases/DownloadTemplateUseCase";
 import i18n from "../../../locales";
 import { cleanOrgUnitPaths } from "../../../utils/dhis";
 import { PartialBy } from "../../../utils/types";
@@ -14,17 +15,6 @@ import Settings from "../../logic/settings";
 import { Select, SelectOption } from "../select/Select";
 
 type DataSource = Record<DataFormType, DataForm[]>;
-
-export interface TemplateSelectorState {
-    type: DataFormType;
-    id: string;
-    populate: boolean;
-    language: string;
-    orgUnits?: string[];
-    theme?: string;
-    startDate?: Moment;
-    endDate?: Moment;
-}
 
 type PickerUnit = "year" | "month" | "date";
 interface PickerFormat {
@@ -36,7 +26,7 @@ interface PickerFormat {
 export interface TemplateSelectorProps {
     settings: Settings;
     themes: Theme[];
-    onChange(state: TemplateSelectorState | null): void;
+    onChange(state: DownloadTemplateProps | null): void;
 }
 
 export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelectorProps) => {
@@ -53,7 +43,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
     const [datePickerFormat, setDatePickerFormat] = useState<PickerFormat>();
     const [userHasReadAccess, setUserHasReadAccess] = useState<boolean>(false);
     const [filterOrgUnits, setFilterOrgUnits] = useState<boolean>(orgUnitSelectionEnabled);
-    const [state, setState] = useState<PartialBy<TemplateSelectorState, "type" | "id">>({
+    const [state, setState] = useState<PartialBy<DownloadTemplateProps, "type" | "id">>({
         startDate: moment().add("-1", "year").startOf("year"),
         endDate: moment(),
         populate: false,
@@ -126,7 +116,14 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
         const model = value as DataFormType;
         const options = modelToSelectOption(dataSource[model]);
 
-        setState(state => ({ ...state, type: model, id: undefined, populate: false }));
+        setState(state => ({
+            ...state,
+            type: model,
+            id: undefined,
+            populate: false,
+            populateStartDate: undefined,
+            populateEndDate: undefined,
+        }));
         setTemplates(options);
         setSelectedOrgUnits([]);
         setOrgUnitTreeFilter([]);
@@ -152,7 +149,13 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
             }
         }
 
-        setState(state => ({ ...state, id: value, populate: false }));
+        setState(state => ({
+            ...state,
+            id: value,
+            populate: false,
+            populateStartDate: undefined,
+            populateEndDate: undefined,
+        }));
         setSelectedOrgUnits([]);
     };
 
@@ -160,16 +163,16 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
         setState(state => ({ ...state, theme: value }));
     };
 
-    const onStartDateChange = (date: Date) => {
+    const onStartDateChange = (field: keyof DownloadTemplateProps, date: Date) => {
         const { unit = "date" } = datePickerFormat ?? {};
         const startDate = date ? moment(date).startOf(unit) : undefined;
-        setState(state => ({ ...state, startDate }));
+        setState(state => ({ ...state, [field]: startDate }));
     };
 
-    const onEndDateChange = (date: Date) => {
+    const onEndDateChange = (field: keyof DownloadTemplateProps, date: Date) => {
         const { unit = "date" } = datePickerFormat ?? {};
         const endDate = date ? moment(date).endOf(unit) : undefined;
-        setState(state => ({ ...state, endDate }));
+        setState(state => ({ ...state, [field]: endDate }));
     };
 
     const onOrgUnitChange = (orgUnitPaths: string[]) => {
@@ -181,7 +184,12 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
     };
 
     const onFilterOrgUnitsChange = (_event: React.ChangeEvent, filterOrgUnits: boolean) => {
-        setState(state => ({ ...state, populate: false }));
+        setState(state => ({
+            ...state,
+            populate: false,
+            populateStartDate: undefined,
+            populateEndDate: undefined,
+        }));
         setFilterOrgUnits(filterOrgUnits);
     };
 
@@ -217,32 +225,34 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                 </div>
             </div>
 
-            <div className={classes.row}>
-                <div className={classes.select}>
-                    <DatePicker
-                        className={classes.fullWidth}
-                        label={i18n.t("Start date")}
-                        value={state.startDate ?? null}
-                        onChange={onStartDateChange}
-                        maxDate={state.endDate}
-                        views={datePickerFormat?.views}
-                        format={datePickerFormat?.format}
-                        InputLabelProps={{ style: { color: "#494949" } }}
-                    />
+            {state.type === "dataSets" && (
+                <div className={classes.row}>
+                    <div className={classes.select}>
+                        <DatePicker
+                            className={classes.fullWidth}
+                            label={i18n.t("Start period")}
+                            value={state.startDate ?? null}
+                            onChange={(date: Date) => onStartDateChange("startDate", date)}
+                            maxDate={state.endDate}
+                            views={datePickerFormat?.views}
+                            format={datePickerFormat?.format}
+                            InputLabelProps={{ style: { color: "#494949" } }}
+                        />
+                    </div>
+                    <div className={classes.select}>
+                        <DatePicker
+                            className={classes.fullWidth}
+                            label={i18n.t("End period")}
+                            value={state.endDate ?? null}
+                            onChange={(date: Date) => onEndDateChange("endDate", date)}
+                            minDate={state.startDate}
+                            views={datePickerFormat?.views}
+                            format={datePickerFormat?.format}
+                            InputLabelProps={{ style: { color: "#494949" } }}
+                        />
+                    </div>
                 </div>
-                <div className={classes.select}>
-                    <DatePicker
-                        className={classes.fullWidth}
-                        label={i18n.t("End date")}
-                        value={state.endDate ?? null}
-                        onChange={onEndDateChange}
-                        minDate={state.startDate}
-                        views={datePickerFormat?.views}
-                        format={datePickerFormat?.format}
-                        InputLabelProps={{ style: { color: "#494949" } }}
-                    />
-                </div>
-            </div>
+            )}
 
             {orgUnitSelectionEnabled && (
                 <React.Fragment>
@@ -323,6 +333,35 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                         control={<Checkbox checked={state.populate} onChange={onPopulateChange} />}
                         label={i18n.t("Populate template with data")}
                     />
+                </div>
+            )}
+
+            {state.populate && (
+                <div className={classes.row}>
+                    <div className={classes.select}>
+                        <DatePicker
+                            className={classes.fullWidth}
+                            label={i18n.t("Start date")}
+                            value={state.populateStartDate ?? null}
+                            onChange={(date: Date) => onStartDateChange("populateStartDate", date)}
+                            maxDate={state.populateEndDate}
+                            views={datePickerFormat?.views}
+                            format={datePickerFormat?.format}
+                            InputLabelProps={{ style: { color: "#494949" } }}
+                        />
+                    </div>
+                    <div className={classes.select}>
+                        <DatePicker
+                            className={classes.fullWidth}
+                            label={i18n.t("End date")}
+                            value={state.populateEndDate ?? null}
+                            onChange={(date: Date) => onEndDateChange("populateEndDate", date)}
+                            minDate={state.populateStartDate}
+                            views={datePickerFormat?.views}
+                            format={datePickerFormat?.format}
+                            InputLabelProps={{ style: { color: "#494949" } }}
+                        />
+                    </div>
                 </div>
             )}
         </React.Fragment>

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -226,7 +226,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                             onChange={(date: Date) => onStartDateChange("startDate", date, true)}
                             maxDate={state.endDate}
                             views={datePickerFormat?.views}
-                            format={datePickerFormat?.format}
+                            format={datePickerFormat?.format ?? "DD/MM/YYYY"}
                             InputLabelProps={{ style: { color: "#494949" } }}
                         />
                     </div>
@@ -238,7 +238,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                             onChange={(date: Date) => onEndDateChange("endDate", date, true)}
                             minDate={state.startDate}
                             views={datePickerFormat?.views}
-                            format={datePickerFormat?.format}
+                            format={datePickerFormat?.format ?? "DD/MM/YYYY"}
                             InputLabelProps={{ style: { color: "#494949" } }}
                         />
                     </div>
@@ -347,7 +347,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                                 ])
                             )}
                             views={datePickerFormat?.views}
-                            format={datePickerFormat?.format}
+                            format={datePickerFormat?.format ?? "DD/MM/YYYY"}
                             InputLabelProps={{ style: { color: "#494949" } }}
                         />
                     </div>
@@ -369,7 +369,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
                                     : undefined
                             }
                             views={datePickerFormat?.views}
-                            format={datePickerFormat?.format}
+                            format={datePickerFormat?.format ?? "DD/MM/YYYY"}
                             InputLabelProps={{ style: { color: "#494949" } }}
                         />
                     </div>

--- a/src/webapp/pages/download-template/DownloadTemplatePage.tsx
+++ b/src/webapp/pages/download-template/DownloadTemplatePage.tsx
@@ -2,11 +2,9 @@ import { Button, makeStyles } from "@material-ui/core";
 import { useLoading, useSnackbar } from "d2-ui-components";
 import React, { useState } from "react";
 import { CompositionRoot } from "../../../CompositionRoot";
+import { DownloadTemplateProps } from "../../../domain/usecases/DownloadTemplateUseCase";
 import i18n from "../../../locales";
-import {
-    TemplateSelector,
-    TemplateSelectorState,
-} from "../../components/template-selector/TemplateSelector";
+import { TemplateSelector } from "../../components/template-selector/TemplateSelector";
 import { useAppContext } from "../../contexts/api-context";
 import { RouteComponentProps } from "../root/RootPage";
 
@@ -16,7 +14,7 @@ export default function DownloadTemplatePage({ settings, themes }: RouteComponen
     const classes = useStyles();
     const { api } = useAppContext();
 
-    const [template, setTemplate] = useState<TemplateSelectorState | null>(null);
+    const [template, setTemplate] = useState<DownloadTemplateProps | null>(null);
 
     const handleTemplateDownloadClick = async () => {
         if (!template) {
@@ -24,23 +22,20 @@ export default function DownloadTemplatePage({ settings, themes }: RouteComponen
             return;
         }
 
-        const { type, startDate, endDate, ...rest } = template;
+        const { type, startDate, endDate, populate, populateStartDate, populateEndDate } = template;
 
         if (type === "dataSets" && (!startDate || !endDate)) {
-            snackbar.info(i18n.t("You need to select start and end dates for dataSet templates"));
+            snackbar.info(i18n.t("You need to select start and end periods for dataSet templates"));
+            return;
+        }
+
+        if (populate && (!populateStartDate || !populateEndDate)) {
+            snackbar.info(i18n.t("You need to select start and end dates to populate template"));
             return;
         }
 
         loading.show(true, i18n.t("Downloading template..."));
-
-        await CompositionRoot.attach().templates.download.execute({
-            api,
-            type,
-            startDate,
-            endDate,
-            ...rest,
-        });
-
+        await CompositionRoot.attach().templates.download.execute(api, template);
         loading.show(false);
     };
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #109 

### :memo: Implementation

- Add new pickers for populate and hide old pickers in programs

### :fire: Notes for the reviewer

- Not sure about what extra validations should we add
  - For dataSets, we could possibly check in populate the startDate and endDate of validations and enforce populate dates are between with ``min`` and ``max`` utilities.
  - However to ensure state is always consistent we should clear ``populate`` dates when changing normal dates

Example of the check, but should be refactored into a utility method:

```tsx
                      <PopulateStartPicker
                            minDate={state.type === "dataSets" ? state.startDate : undefined}
                            maxDate={
                                state.type === "dataSets"
                                    ? moment.min(_.compact([state.endDate, state.populateEndDate]))
                                    : state.populateEndDate
                            }
                       />
                      <PopulateEndPicker
                            minDate={
                                state.type === "dataSets"
                                    ? moment.max(
                                          _.compact([state.startDate, state.populateStartDate])
                                      )
                                    : state.populateStartDate
                            }
                            maxDate={state.type === "dataSets" ? state.endDate : undefined}
                       />
```

![image](https://user-images.githubusercontent.com/2181866/83485110-9c2de000-a4a6-11ea-8a54-e8cbcd1d2d47.png)

### :art: Screenshots

### :bookmark_tabs: Others
