### PR TITLE
Sort data elements to mimic dhis2 getForm

### DIFF
--- a/src/webapp/logic/dhisConnector.js
+++ b/src/webapp/logic/dhisConnector.js
@@ -3,7 +3,7 @@ import { promiseMap } from "../utils/promises";
 
 export async function getElement(api, type, id) {
     const fields =
-        "id,displayName,organisationUnits[id,path],attributeValues[attribute[code],value],categoryCombo,dataSetElements,sections,periodType,programStages";
+        "id,displayName,organisationUnits[id,path],attributeValues[attribute[code],value],categoryCombo,dataSetElements,formType,sections[id,sortOrder,dataElements[id]],periodType,programStages";
     const response = await api.get(`/${type}/${id}`, { fields }).getData();
     return { ...response, type };
 }

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -318,66 +318,49 @@ SheetBuilder.prototype.fillDataEntrySheet = function () {
         .style({ ...baseStyle, font: { size: 16, bold: true } });
 
     if (element.type === "dataSets") {
-        const categoryOptionCombos = [];
-        for (const [, value] of metadata) {
-            if (value.type === "categoryOptionCombos") {
-                categoryOptionCombos.push(value);
+        const dataElements = getDataElements(element, metadata);
+
+        _.forEach(dataElements, ({ dataElement, categoryOptionCombos }) => {
+            const { name, description } = this.translate(dataElement);
+            const firstColumnId = columnId;
+
+            _.forEach(categoryOptionCombos, categoryOptionCombo => {
+                const validation = dataElement.optionSet
+                    ? dataElement.optionSet.id
+                    : dataElement.valueType;
+                this.createColumn(
+                    dataEntrySheet,
+                    itemRow,
+                    columnId,
+                    `_${categoryOptionCombo.id}`,
+                    groupId,
+                    this.validations.get(validation),
+                    undefined,
+                    categoryOptionCombo.code === "default"
+                );
+
+                columnId++;
+            });
+
+            if (columnId - 1 === firstColumnId) {
+                dataEntrySheet.column(firstColumnId).setWidth(name.length / 2.5 + 15);
             }
-        }
 
-        const sections = _.groupBy(categoryOptionCombos, "categoryCombo.id");
-        _.forOwn(sections, (_section, categoryComboId) => {
-            const categoryCombo = metadata.get(categoryComboId);
-            if (categoryCombo !== undefined) {
-                _(element.dataSetElements)
-                    .map(({ dataElement }) => metadata.get(dataElement.id))
-                    .filter({
-                        categoryCombo: { id: categoryComboId },
-                    })
-                    .forEach(dataElement => {
-                        const { name, description } = this.translate(dataElement);
-                        const firstColumnId = columnId;
+            dataEntrySheet
+                .cell(sectionRow, firstColumnId, sectionRow, columnId - 1, true)
+                .formula(`_${dataElement.id}`)
+                .style(this.groupStyle(groupId));
 
-                        const sectionCategoryOptionCombos = sections[categoryComboId];
-                        _.forEach(sectionCategoryOptionCombos, categoryOptionCombo => {
-                            const validation = dataElement.optionSet
-                                ? dataElement.optionSet.id
-                                : dataElement.valueType;
-                            this.createColumn(
-                                dataEntrySheet,
-                                itemRow,
-                                columnId,
-                                `_${categoryOptionCombo.id}`,
-                                groupId,
-                                this.validations.get(validation),
-                                undefined,
-                                categoryOptionCombo.code === "default"
-                            );
-
-                            columnId++;
-                        });
-
-                        if (columnId - 1 === firstColumnId) {
-                            dataEntrySheet.column(firstColumnId).setWidth(name.length / 2.5 + 15);
-                        }
-
-                        dataEntrySheet
-                            .cell(sectionRow, firstColumnId, sectionRow, columnId - 1, true)
-                            .formula(`_${dataElement.id}`)
-                            .style(this.groupStyle(groupId));
-
-                        if (description !== undefined) {
-                            dataEntrySheet
-                                .cell(sectionRow, firstColumnId, sectionRow, columnId - 1, true)
-                                .comment(description, {
-                                    height: "100pt",
-                                    width: "160pt",
-                                });
-                        }
-
-                        groupId++;
+            if (description !== undefined) {
+                dataEntrySheet
+                    .cell(sectionRow, firstColumnId, sectionRow, columnId - 1, true)
+                    .comment(description, {
+                        height: "100pt",
+                        width: "160pt",
                     });
             }
+
+            groupId++;
         });
     } else {
         _.forEach(element.programStages, programStageT => {
@@ -558,6 +541,72 @@ SheetBuilder.prototype.groupStyle = function (groupId) {
         },
     };
 };
+
+function getDataElementsForSectionDataSet(dataSet, metadata, cocsByCatComboId) {
+    return _(dataSet.sections)
+        .sortBy(section => section.sortOrder)
+        .flatMap(section => {
+            return (
+                _(section.dataElements)
+                    .map(({ id }) => metadata.get(id))
+                    .compact()
+                    .groupBy(dataElement => dataElement.categoryCombo?.id)
+                    .toPairs()
+                    // Order of category combos is indeterminate in loadForm.action,
+                    // but apply the same criteria usen in formType DEFAULT.
+                    .sortBy(([ccId, _dataElements]) => cocsByCatComboId[ccId]?.length)
+                    .flatMap(([_categoryComboId, dataElements]) => {
+                        // Keep order for data elements in section from the response API
+                        return _(dataElements)
+                            .map(dataElement => ({
+                                dataElement,
+                                categoryOptionCombos:
+                                    cocsByCatComboId[dataElement.categoryCombo.id] || [],
+                            }))
+                            .value();
+                    })
+                    .value()
+            );
+        })
+        .value();
+}
+
+function getDataElementsForDefaultDataSet(dataSet, metadata, cocsByCatComboId) {
+    return (
+        _(cocsByCatComboId)
+            .toPairs()
+            // Mimic loadForm.action, sort category combos by cocs length
+            .sortBy(([_ccId, categoryOptionCombos]) => categoryOptionCombos.length)
+            .flatMap(([categoryComboId, categoryOptionCombos]) => {
+                const categoryCombo = metadata.get(categoryComboId);
+                if (!categoryCombo) return [];
+
+                // Mimic loadForm.action, sort data elements (in a category combo) by name
+                return _(dataSet.dataSetElements)
+                    .map(({ dataElement }) => metadata.get(dataElement.id))
+                    .compact()
+                    .filter({ categoryCombo: { id: categoryComboId } })
+                    .sortBy(dataElement => dataElement.name)
+                    .map(dataElement => ({ dataElement, categoryOptionCombos }))
+                    .value();
+            })
+            .value()
+    );
+}
+
+function getDataElements(dataSet, metadata) {
+    const objs = Array.from(metadata.values());
+    const categoryOptionCombos = objs.filter(obj => obj.type === "categoryOptionCombos");
+    const cocsByCatComboId = _.groupBy(categoryOptionCombos, "categoryCombo.id");
+
+    switch (dataSet.formType) {
+        case "SECTION":
+            return getDataElementsForSectionDataSet(dataSet, metadata, cocsByCatComboId);
+        default:
+            // "DEFAULT" | "CUSTOM" | "SECTION_MULTIORG"
+            return getDataElementsForDefaultDataSet(dataSet, metadata, cocsByCatComboId);
+    }
+}
 
 /**
  * Common cell style definition


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #138 

### :memo: Implementation

How loadForm.action works:

- `formType = "SECTION"`: sections are ordered. Order of category combos within a section is indetermined. Within a category combo, the order of the data elements is kept from the original order in the section.
- Others: order of category combos is stablished by size of cocs associated to it (ASC). For the same number of cocs, the order is indeterminate. Within a category combo, data elements are sorted by name.

The original generated spreadsheet shows non-product cocs of on multi-category data elements, which is weird. So, I have some code to generate the cartesian product of category options (as data-entry does), but I've not committed it here, it's complex and needs some previous discussion because of the current behaviour.