### PR TITLE
Change summary tracker programs

### DIFF
--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -673,9 +673,20 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
                     {importState.dataForm.id})
                     {importState.summary.map((group, idx) => (
                         <li key={idx} style={{ marginLeft: 10, fontSize: "1em" }}>
-                            {moment(String(group.period)).format("DD/MM/YYYY")}:{" "}
-                            {group.id ? i18n.t("Update") : i18n.t("Create")} {group.count}{" "}
-                            {i18n.t("data values")} {group.id && `(${group.id})`}
+                            {importState.dataForm.type === "trackerPrograms" ? (
+                                <React.Fragment>
+                                    {moment(String(group.period)).format("DD/MM/YYYY")}:{" "}
+                                    {group.id ? i18n.t("Create/update") : i18n.t("Create")} {""}
+                                    {i18n.t("event")} {""}
+                                    {group.id}
+                                </React.Fragment>
+                            ) : (
+                                <React.Fragment>
+                                    {moment(String(group.period)).format("DD/MM/YYYY")}:{" "}
+                                    {group.id ? i18n.t("Update") : i18n.t("Create")} {group.count}{" "}
+                                    {i18n.t("data values")} {group.id && `(${group.id})`}
+                                </React.Fragment>
+                            )}
                         </li>
                     ))}
                 </div>


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #169

### :memo: Implementation

The original idea of changing the counts in the snackbar is not possible due to the weird responses returned by the POST events endpoint, which is, for the record (E: Events, DV: Datavalue):

- On events without ID (create): "imported: E+DV" 
- ON events with ID (update): "update: E"

To avoid confusion, we now simply hide the data values info in the summary (only for tracker programs)

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/96991324-8dfd6080-1528-11eb-835c-2d5b682587f9.png)
