### PR TITLE
[Data sets] Render sorted COCs for data elements disaggregation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "file-saver": "2.0.2",
         "jquery": "3.5.0",
         "lodash": "4.17.15",
+        "lodash.product": "^18.9.19",
         "md5": "^2.3.0",
         "moment": "2.24.0",
         "prop-types": "15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9885,6 +9885,11 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lodash.product@^18.9.19:
+  version "18.9.19"
+  resolved "https://registry.npmjs.org/lodash.product/-/lodash.product-18.9.19.tgz#c1f49a4b447869290a8799c29295703fda294835"
+  integrity sha512-yPX6KO0jveBR/DjSngqvUEynWTb4oJwB8g5WseShPzX0CO8pjX1gxlR5Fo7V3E81uPDc9mEuNVw3Ah6df9uy0g==
+
 lodash.reduce@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #155

### :memo: Implementation

As we know from other projects, `categoryCombo.categoryOptionCombos` does not return an ordered collection, so we have to manually build the cartesian product of `category.categoryOptions` for every `categoryCombo.category`.

### :fire: Notes for the reviewer

Data set `BU - minimum aggregated data_Annual_Disaggregated` contains data elements with multiple categories, so the cartesian product can be seen.

Note how some COCs have the category options swaped. That's because the COC was generated that way in the backend and since we are using indirect `=_ID` render, it's not fixable on our side. The COC should have the correct name in the backend. Data Administration -> Update category option combos does not fix these names.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/97079778-e307a800-15f6-11eb-8dc5-6f773efd271a.png)
