### PR TITLE
[import:TEI] Use organisation unit override

### DIFF
--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -2,15 +2,17 @@ import _ from "lodash";
 import {
     SynchronizationResult,
     SynchronizationStats,
+    SynchronizationStatus,
 } from "../domain/entities/SynchronizationResult";
 import i18n from "../locales";
 
-type Status = "SUCCESS" | "ERROR";
+type Status = "OK" | "ERROR";
 
 export interface ImportPostResponse {
     status: Status;
     message?: string;
     response?: {
+        status: SynchronizationStatus;
         imported: number;
         updated: number;
         deleted: number;
@@ -43,7 +45,8 @@ export function processImportResponse(options: {
     splitStatsList: boolean;
 }): SynchronizationResult {
     const { title, model, importResult, splitStatsList } = options;
-    const { status, message, response } = importResult;
+    const { message, response } = importResult;
+    const status = response ? response.status : "ERROR";
 
     if (!response) return { title, status, message, rawResponse: importResult };
 

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -113,15 +113,12 @@ export async function updateTrackedEntityInstances(
         .first();
     if (!programId) throw new Error("Cannot get program from TEIs");
 
-    const orgUnitIDs = _(teis)
-        .map(tei => tei.orgUnit.id)
-        .uniq()
-        .value();
+    const orgUnitIds = _.uniq(teis.map(tei => tei.orgUnit.id));
 
     const existingTeis = await getTrackedEntityInstances({
         api,
         program: { id: programId },
-        orgUnits: orgUnitIDs.map(id => ({ id })),
+        orgUnits: orgUnitIds.map(id => ({ id })),
     });
 
     const program = await getProgram(api, programId);
@@ -132,11 +129,24 @@ export async function updateTrackedEntityInstances(
     const [preTeis, postTeis] = splitTeis(teis, existingTeis);
 
     const options = { api, program, metadata, existingTeis };
-    const teiResponsesPre = await uploadTeis({ ...options, teis: preTeis });
-    const teiResponsesPost = await uploadTeis({ ...options, teis: postTeis });
-    const eventsResponse = await postEvents(api, apiEvents);
 
-    return _.compact([teiResponsesPre, teiResponsesPost, eventsResponse]);
+    return runSequentialPromisesOnSuccess([
+        () => uploadTeis({ ...options, teis: preTeis }),
+        () => uploadTeis({ ...options, teis: postTeis }),
+        () => postEvents(api, apiEvents),
+    ]);
+}
+
+async function runSequentialPromisesOnSuccess(
+    fns: Array<() => Promise<SynchronizationResult | undefined>>
+): Promise<SynchronizationResult[]> {
+    const output: SynchronizationResult[] = [];
+    for (const fn of fns) {
+        const res = await fn();
+        if (res) output.push(res);
+        if (res && res.status !== "SUCCESS") break;
+    }
+    return output;
 }
 
 // Private

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -165,10 +165,11 @@ export class ImportTemplateUseCase implements UseCase {
                       );
                   });
 
-        const trackedEntityInstances =
-            excelDataValues.type === "trackerPrograms"
-                ? excelDataValues.trackedEntityInstances
-                : [];
+        const trackedEntityInstances = getTrackedEntityInstances(
+            excelDataValues,
+            useBuilderOrgUnits,
+            selectedOrgUnits
+        );
 
         return {
             dataValues: {
@@ -202,6 +203,20 @@ export class ImportTemplateUseCase implements UseCase {
             translateCodes: false,
         });
     }
+}
+
+function getTrackedEntityInstances(
+    excelDataValues: DataPackage,
+    useBuilderOrgUnits: boolean,
+    selectedOrgUnitPaths: string[]
+) {
+    const orgUnitOverridePath = useBuilderOrgUnits ? selectedOrgUnitPaths[0] : null;
+    const teis =
+        excelDataValues.type === "trackerPrograms" ? excelDataValues.trackedEntityInstances : [];
+
+    return orgUnitOverridePath
+        ? teis.map(tei => ({ ...tei, orgUnit: { id: cleanOrgUnitPath(orgUnitOverridePath) } }))
+        : teis;
 }
 
 const compareDataPackages = (


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #181

### :memo: Implementation

- Same than dataValues, override orgUnit from builder.
- Lateral change: on TEI import we have 3 requests: pre-TEI, post-TEI, events. Now we stop on the first unsuccessful request.