### PR TITLE
[Fix] Send events in chunks

### DIFF
--- a/src/domain/entities/SynchronizationResult.ts
+++ b/src/domain/entities/SynchronizationResult.ts
@@ -1,7 +1,5 @@
 export type SynchronizationStatus = "PENDING" | "SUCCESS" | "WARNING" | "ERROR" | "NETWORK ERROR";
 
-export type SynchronizationResults = SynchronizationResult[];
-
 export interface SynchronizationStats {
     type?: string;
     imported: number;

--- a/src/test/DownloadTemplatePage.spec.tsx
+++ b/src/test/DownloadTemplatePage.spec.tsx
@@ -31,7 +31,7 @@ const renderComponent = async () => {
     });
 };
 
-describe.skip("ImportTemplatePage", () => {
+describe("ImportTemplatePage", () => {
     beforeAll(async () => {
         CompositionRoot.initialize({
             appConfig: {

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -114,7 +114,7 @@ export function initializeMockServer() {
         params: {
             paging: false,
             fields:
-                "access,attributeValues[attribute[code],value],displayName,id,name,programStages[programStageDataElements[dataElement[formName,id,name]]],programType",
+                "access,attributeValues[attribute[code],value],displayName,id,name,programStages[programStageDataElements[dataElement[formName,id,name]]],programType,trackedEntityType",
             filter: [],
         },
     }).reply(200, {

--- a/src/webapp/logic/dhisConnector.js
+++ b/src/webapp/logic/dhisConnector.js
@@ -55,14 +55,6 @@ export async function getElementMetadata({ element, api, orgUnitIds }) {
     return { element, metadata, elementMetadata, organisationUnits, rawMetadata };
 }
 
-export async function importData({ element, api, data }) {
-    const isProgram = element.type === "programs" || element.type === "trackerPrograms";
-    const endpoint = isProgram ? "/events" : "/dataValueSets";
-    const object = isProgram ? { events: data } : { dataValues: data };
-    const response = await api.post(endpoint, {}, object).getData();
-    return response;
-}
-
 export function importOrgUnitByUID(api, uid) {
     return api.get("/organisationUnits/" + uid).getData();
 }

--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -846,7 +846,7 @@ async function importEventsData(api: D2Api, data: Event[]): Promise<ImportPostRe
     const response = await sendEvents(data);
 
     // See https://jira.dhis2.org/browse/DHIS2-9936
-    if (response.status === "ERROR" && response.message === "no transaction is in progress") {
+    if (response.status === "ERROR") {
         return promiseMap(_.chunk(data, 99), events => sendEvents(events));
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4040,9 +4040,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001043:
-  version "1.0.30001048"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz#4bb4f1bc2eb304e5e1154da80b93dee3f1cf447e"
-  integrity sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==
+  version "1.0.30001166"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001166.tgz"
+  integrity sha512-nCL4LzYK7F4mL0TjEMeYavafOGnBa98vTudH5c8lW9izUjnB99InG6pmC1ElAI1p0GlyZajv4ltUdFXvOHIl1A==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- Detect error and attempt sending the events in chunks
- If there are no errors we don't paginate

### :fire: Notes for the reviewer

Performance on a docker with a simple program but thousands of events:

- DHIS2 2.34 previous to the official fix (workaround: send in chunks of 99 events at a time)
- UI doesn't feel responsive (process takes too long it seems it has hung, but working behind the scenes)
- Bulk-Load tab on Chrome used 1.2GB of RAM memory itself
- Duplicate check (with 8k events already stored) elapsed a total of 5.38 minutes (with almost 100% CPU usage on Intel i7)
- Importing 20k events elapsed a total of 22 minutes (with CPU usage below 15%)

### :art: Screenshots

### :bookmark_tabs: Others

- Should we disable duplicate check when working with large amounts of events?
- The UI of the ``SyncSummary`` contains each network request independently, merging them is tricky when it comes down to detect issues. The downside is that the list is not virtualized and it can be difficult to scroll/review all items.
- We should implement ``async`` methods somewhere in the near future to avoid timeouts.