### PR TITLE
Show category combo as compulsory column on programs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bulk-load",
     "description": "Bulk importing made easy",
-    "version": "3.9.0",
+    "version": "3.10.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -414,7 +414,7 @@ SheetBuilder.prototype.fillValidationSheet = function () {
 };
 
 SheetBuilder.prototype.fillMetadataSheet = function () {
-    const { elementMetadata: metadata, organisationUnits } = this.builder;
+    const { elementMetadata: metadata, organisationUnits, element } = this.builder;
     const metadataSheet = this.metadataSheet;
 
     // Freeze and format column titles
@@ -441,14 +441,18 @@ SheetBuilder.prototype.fillMetadataSheet = function () {
             .map(option => this.translate(option).name)
             .join(", ");
 
-        const { compulsory } =
-            this.builder.rawMetadata.programStageDataElements?.find(
-                ({ dataElement }) => dataElement.id === item.id
-            ) ?? {};
+        const isProgramStageDataElementCompulsory = _.some(
+            this.builder.rawMetadata.programStageDataElements,
+            ({ dataElement, compulsory }) => dataElement.id === item.id && compulsory
+        );
+
+        const isCompulsory =
+            isProgramStageDataElementCompulsory ||
+            (element.type === "programs" && item.type === "categoryCombos");
 
         metadataSheet.cell(rowId, 1).string(item.id ?? "");
         metadataSheet.cell(rowId, 2).string(item.type ?? "");
-        metadataSheet.cell(rowId, 3).string(name?.concat(compulsory ? " *" : "") ?? "");
+        metadataSheet.cell(rowId, 3).string(name?.concat(isCompulsory ? " *" : "") ?? "");
         metadataSheet.cell(rowId, 4).string(item.valueType ?? "");
         metadataSheet.cell(rowId, 5).string(optionSetName ?? "");
         metadataSheet.cell(rowId, 6).string(options ?? "");

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -446,9 +446,10 @@ SheetBuilder.prototype.fillMetadataSheet = function () {
             ({ dataElement, compulsory }) => dataElement.id === item.id && compulsory
         );
 
+        const isProgram = element.type === "programs" || isTrackerProgram(element);
+
         const isCompulsory =
-            isProgramStageDataElementCompulsory ||
-            (element.type === "programs" && item.type === "categoryCombos");
+            isProgramStageDataElementCompulsory || (isProgram && item.type === "categoryCombos");
 
         metadataSheet.cell(rowId, 1).string(item.id ?? "");
         metadataSheet.cell(rowId, 2).string(item.type ?? "");


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/dk3qqc

### :memo: Implementation

- Headers use named cells (`=_ID`) so we cannot add the ` *` suffix there. Therefore, we add the suffix to the name in the metadata sheet, as we do for compulsory program-stage data elements.
- This applies only to programs. Sheets for dataSets and tracker programs are unaffected (aren't they also compulsory?)

