### PR TITLE
[Fix] Rich text detection on production builds

### DIFF
--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -461,7 +461,8 @@ function _getFormulaWithValidation(workbook: XLSX.Workbook, sheet: SheetWithVali
 function getValue(cell: Cell): ExcelValue | undefined {
     const value = cell.value();
 
-    if (typeof value === "object" && value.constructor.name === "RichText") {
+    //@ts-ignore This should be improved on xlsx-populate
+    if (typeof value === "object" && _.isFunction(value.text)) {
         // @ts-ignore This should be improved on xlsx-populate
         const result = value.text();
 


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- Fix production-only issue with RichText cells

### :fire: Notes for the reviewer

### :art: Screenshots

### :bookmark_tabs: Others

- We should properly address this in the future, the return types of RichTexts from ``xlsx-populate`` are not consistent and this is a workaround that we want not to face on other projects that use the library (predictors ie)
