### PR TITLE
Extend data set feature (use sections on generate + add setting data elements filter)

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 SKIP_PREFLIGHT_CHECK=true
 PORT=8081
 BROWSER=false
-REACT_APP_DHIS2_BASE_URL=http://dev2.eyeseetea.com:8082
+REACT_APP_DHIS2_BASE_URL=http://localhost:8080

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
-"PO-Revision-Date: 2021-03-30T11:42:25.413Z\n"
+"POT-Creation-Date: 2021-04-06T09:08:39.336Z\n"
+"PO-Revision-Date: 2021-04-06T09:08:39.336Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -77,6 +77,9 @@ msgid "Program"
 msgstr ""
 
 msgid "Data set"
+msgstr ""
+
+msgid "Search data elements"
 msgstr ""
 
 msgid "Access to Template Generation"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-17T09:48:30.489Z\n"
-"PO-Revision-Date: 2021-02-17T09:48:30.489Z\n"
+"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
+"PO-Revision-Date: 2021-03-30T11:42:25.413Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -64,6 +64,9 @@ msgstr ""
 msgid "You need to select at least one {{element}}"
 msgstr ""
 
+msgid "All"
+msgstr ""
+
 msgid "Data elements used for duplication assessment"
 msgstr ""
 
@@ -71,6 +74,9 @@ msgid "Close"
 msgstr ""
 
 msgid "Program"
+msgstr ""
+
+msgid "Data set"
 msgstr ""
 
 msgid "Access to Template Generation"
@@ -144,10 +150,21 @@ msgstr ""
 msgid "Not accessible"
 msgstr ""
 
+msgid "Data elements filter for data sets"
+msgstr ""
+
 msgid "Data model"
 msgstr ""
 
 msgid "Organisation Unit Visibility"
+msgstr ""
+
+msgid "Columns layout"
+msgstr ""
+
+msgid ""
+"Data elements (with optional disaggregation) to include/exclude for data "
+"sets"
 msgstr ""
 
 msgid "Duplicate detection"
@@ -205,9 +222,6 @@ msgid "Messages"
 msgstr ""
 
 msgid "JSON Response"
-msgstr ""
-
-msgid "All"
 msgstr ""
 
 msgid "Data Set"
@@ -333,9 +347,6 @@ msgid "Error deleting data values"
 msgstr ""
 
 msgid "Select at least one model"
-msgstr ""
-
-msgid "Data set"
 msgstr ""
 
 msgid "Cannot get data entry sheet"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2021-02-17T09:48:30.489Z\n"
+"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,6 +64,9 @@ msgstr "El campo {{field}} no se puede dejar vacio"
 msgid "You need to select at least one {{element}}"
 msgstr "Seleccione al menos un {{element}}"
 
+msgid "All"
+msgstr "Todos"
+
 msgid "Data elements used for duplication assessment"
 msgstr "Elementos de datos usados para determinar los duplicados"
 
@@ -72,6 +75,9 @@ msgstr "Cerrar"
 
 msgid "Program"
 msgstr "Programa"
+
+msgid "Data set"
+msgstr "Set de datos"
 
 msgid "Access to Template Generation"
 msgstr "Acceso a la generación de plantillas"
@@ -149,11 +155,22 @@ msgstr "Solo accesible a los administradores del sistema"
 msgid "Not accessible"
 msgstr "No accesible"
 
+#, fuzzy
+msgid "Data elements filter for data sets"
+msgstr "Filtro de elementos de datos para eventos (programas)"
+
 msgid "Data model"
 msgstr "Modelos de Datos"
 
 msgid "Organisation Unit Visibility"
 msgstr "Visibilidad de unidades organizativas"
+
+msgid "Columns layout"
+msgstr ""
+
+msgid ""
+"Data elements (with optional disaggregation) to include/exclude for data sets"
+msgstr ""
 
 msgid "Duplicate detection"
 msgstr "Detección de duplicados"
@@ -213,9 +230,6 @@ msgstr ""
 
 msgid "JSON Response"
 msgstr ""
-
-msgid "All"
-msgstr "Todos"
 
 msgid "Data Set"
 msgstr "Data Set"
@@ -341,9 +355,6 @@ msgstr "Se ha producido un error borrando valores de datos"
 
 msgid "Select at least one model"
 msgstr "Seleccione al menos una plantilla"
-
-msgid "Data set"
-msgstr "Set de datos"
 
 msgid "Cannot get data entry sheet"
 msgstr "No se puede leer la hoja de entrada de datos"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
+"POT-Creation-Date: 2021-04-06T09:08:39.336Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -79,6 +79,9 @@ msgstr "Programa"
 msgid "Data set"
 msgstr "Set de datos"
 
+msgid "Search data elements"
+msgstr "Buscar elementos de datos"
+
 msgid "Access to Template Generation"
 msgstr "Acceso a la generación de plantillas"
 
@@ -155,9 +158,8 @@ msgstr "Solo accesible a los administradores del sistema"
 msgid "Not accessible"
 msgstr "No accesible"
 
-#, fuzzy
 msgid "Data elements filter for data sets"
-msgstr "Filtro de elementos de datos para eventos (programas)"
+msgstr "Filtro de elementos de datos (set de datos)"
 
 msgid "Data model"
 msgstr "Modelos de Datos"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2021-02-17T09:48:30.489Z\n"
+"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,6 +64,9 @@ msgstr "Le champ {{field}} ne peut pas être vide"
 msgid "You need to select at least one {{element}}"
 msgstr "Vous devez sélectionner au moins un {{element}}"
 
+msgid "All"
+msgstr "Tout"
+
 msgid "Data elements used for duplication assessment"
 msgstr "Éléments de données utilisés pour l'évaluation des doublons"
 
@@ -72,6 +75,9 @@ msgstr "Fermer"
 
 msgid "Program"
 msgstr "Programme"
+
+msgid "Data set"
+msgstr "Ensamble de donées"
 
 msgid "Access to Template Generation"
 msgstr "Accès à la génération de modèles"
@@ -148,11 +154,22 @@ msgstr "Accessible uniquement aux administrateurs du système"
 msgid "Not accessible"
 msgstr "Pas accessible"
 
+#, fuzzy
+msgid "Data elements filter for data sets"
+msgstr "Filtre des éléments de données pour les programmes des événements"
+
 msgid "Data model"
 msgstr "Modèle de données"
 
 msgid "Organisation Unit Visibility"
 msgstr "Visibilité de l'unité d'organisation"
+
+msgid "Columns layout"
+msgstr ""
+
+msgid ""
+"Data elements (with optional disaggregation) to include/exclude for data sets"
+msgstr ""
 
 msgid "Duplicate detection"
 msgstr "Détection des doublons"
@@ -210,9 +227,6 @@ msgstr ""
 
 msgid "JSON Response"
 msgstr ""
-
-msgid "All"
-msgstr "Tout"
 
 msgid "Data Set"
 msgstr "Base de données"
@@ -340,9 +354,6 @@ msgstr "Erreur lors de la suppression des valeurs de données"
 
 msgid "Select at least one model"
 msgstr "Sélectionnez au moins un modèle"
-
-msgid "Data set"
-msgstr "Ensamble de donées"
 
 msgid "Cannot get data entry sheet"
 msgstr "Impossible d'obtenir la feuille de saisie des données"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
+"POT-Creation-Date: 2021-04-06T09:08:39.336Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -79,6 +79,9 @@ msgstr "Programme"
 msgid "Data set"
 msgstr "Ensamble de donées"
 
+msgid "Search data elements"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Accès à la génération de modèles"
 
@@ -154,9 +157,8 @@ msgstr "Accessible uniquement aux administrateurs du système"
 msgid "Not accessible"
 msgstr "Pas accessible"
 
-#, fuzzy
 msgid "Data elements filter for data sets"
-msgstr "Filtre des éléments de données pour les programmes des événements"
+msgstr "Filtre des éléments de données (ensembles de données)"
 
 msgid "Data model"
 msgstr "Modèle de données"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-02-17T09:48:30.489Z\n"
+"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
 "PO-Revision-Date: 2020-06-11T08:45:45.996Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -63,6 +63,9 @@ msgstr "O campo {{field}} não pode ficar em branco"
 msgid "You need to select at least one {{element}}"
 msgstr "Você precisa selecionar pelo menos um {{element}}"
 
+msgid "All"
+msgstr "Tudo"
+
 msgid "Data elements used for duplication assessment"
 msgstr "Elementos de dados usados para avaliação de duplicação"
 
@@ -71,6 +74,9 @@ msgstr "Fechar"
 
 msgid "Program"
 msgstr "Programa"
+
+msgid "Data set"
+msgstr "Data Set"
 
 msgid "Access to Template Generation"
 msgstr "Acesso à geração de planilhas"
@@ -145,11 +151,22 @@ msgstr "Acessível apenas para administradores de sistema"
 msgid "Not accessible"
 msgstr "Não acessível"
 
+#, fuzzy
+msgid "Data elements filter for data sets"
+msgstr "Filtro de elementos de dados for events (programs)"
+
 msgid "Data model"
 msgstr "Modelo de dados"
 
 msgid "Organisation Unit Visibility"
 msgstr "Visibilidade da unidade organizacional"
+
+msgid "Columns layout"
+msgstr ""
+
+msgid ""
+"Data elements (with optional disaggregation) to include/exclude for data sets"
+msgstr ""
 
 msgid "Duplicate detection"
 msgstr "Detecção duplicada"
@@ -207,9 +224,6 @@ msgstr ""
 
 msgid "JSON Response"
 msgstr ""
-
-msgid "All"
-msgstr "Tudo"
 
 msgid "Data Set"
 msgstr "Data Set"
@@ -335,9 +349,6 @@ msgstr "Erro ao excluir valores de dados"
 
 msgid "Select at least one model"
 msgstr "Selecione pelo menos uma planilha"
-
-msgid "Data set"
-msgstr "Data Set"
 
 msgid "Cannot get data entry sheet"
 msgstr "Não é possível obter a folha de registro de dados"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-03-30T11:42:25.413Z\n"
+"POT-Creation-Date: 2021-04-06T09:08:39.336Z\n"
 "PO-Revision-Date: 2020-06-11T08:45:45.996Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -78,6 +78,9 @@ msgstr "Programa"
 msgid "Data set"
 msgstr "Data Set"
 
+msgid "Search data elements"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Acesso à geração de planilhas"
 
@@ -151,9 +154,8 @@ msgstr "Acessível apenas para administradores de sistema"
 msgid "Not accessible"
 msgstr "Não acessível"
 
-#, fuzzy
 msgid "Data elements filter for data sets"
-msgstr "Filtro de elementos de dados for events (programs)"
+msgstr "Filtro de elementos de dados (fichas)"
 
 msgid "Data model"
 msgstr "Modelo de dados"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bulk-load",
     "description": "Bulk importing made easy",
-    "version": "3.10.1",
+    "version": "3.11",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.1.3",
         "@dhis2/ui-core": "4.17.1",
         "@dhis2/ui-widgets": "2.1.0",
-        "@eyeseetea/d2-ui-components": "2.5.2",
+        "@eyeseetea/d2-ui-components": "2.6.3-beta.2",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.11.3",
         "@material-ui/icons": "4.11.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.1.3",
         "@dhis2/ui-core": "4.17.1",
         "@dhis2/ui-widgets": "2.1.0",
-        "@eyeseetea/d2-ui-components": "2.6.3-beta.2",
+        "@eyeseetea/d2-ui-components": "2.6.3",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.11.3",
         "@material-ui/icons": "4.11.2",

--- a/src/data/ConfigWebRepository.ts
+++ b/src/data/ConfigWebRepository.ts
@@ -33,6 +33,7 @@ export class ConfigWebRepository implements ConfigRepository {
             duplicateExclusion: {},
             duplicateTolerance: 1,
             duplicateToleranceUnit: "day",
+            dataSetDataElementsFilter: {},
             ...defaultSettings,
         };
     }

--- a/src/domain/entities/AppSettings.ts
+++ b/src/domain/entities/AppSettings.ts
@@ -1,13 +1,16 @@
 import { GetArrayInnerType } from "../../types/utils";
+import { DataElementDisaggregated } from "./DataElementDisaggregated";
 import { Id } from "./ReferenceObject";
 
 const models = ["dataSet", "program"] as const;
 export type Model = GetArrayInnerType<typeof models>;
 export type Models = Record<Model, boolean>;
+type DataSetId = Id;
 
 export type OrgUnitSelectionSetting = "generation" | "import" | "both";
 export type DuplicateToleranceUnit = "day" | "week" | "month" | "year";
 export type DuplicateExclusion = Record<Id, Id[]>;
+export type DataSetDataElementsFilter = Record<DataSetId, DataElementDisaggregated[]>;
 
 export interface AppSettings {
     models: Record<Model, boolean>;
@@ -19,4 +22,5 @@ export interface AppSettings {
     duplicateExclusion: DuplicateExclusion;
     duplicateTolerance: number;
     duplicateToleranceUnit: DuplicateToleranceUnit;
+    dataSetDataElementsFilter: DataSetDataElementsFilter;
 }

--- a/src/domain/entities/DataElementDisaggregated.ts
+++ b/src/domain/entities/DataElementDisaggregated.ts
@@ -1,0 +1,19 @@
+import { Id } from "./ReferenceObject";
+
+const idSeparator = "-";
+
+export interface DataElementDisaggregated {
+    id: Id;
+    categoryOptionComboId?: Id;
+}
+
+export type DataElementDisaggregatedId = string; // ${de.id}-${coc.id}
+
+export function getDataElementDisaggregatedId(de: DataElementDisaggregated): DataElementDisaggregatedId {
+    return [de.id, de.categoryOptionComboId].filter(Boolean).join(idSeparator);
+}
+
+export function getDataElementDisaggregatedById(id: string): DataElementDisaggregated {
+    const [dataElementId = "", cocId] = id.split(idSeparator, 2);
+    return cocId ? { id: dataElementId, categoryOptionComboId: cocId } : { id: dataElementId };
+}

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { Moment } from "moment";
 import { UseCase } from "../../CompositionRoot";
 import * as dhisConnector from "../../webapp/logic/dhisConnector";
+import Settings from "../../webapp/logic/settings";
 import { getTemplateId, SheetBuilder } from "../../webapp/logic/sheetBuilder";
 import { DataFormType } from "../entities/DataForm";
 import { Id } from "../entities/ReferenceObject";
@@ -23,6 +24,7 @@ export interface DownloadTemplateProps {
     populateStartDate?: Moment;
     populateEndDate?: Moment;
     writeFile?: string;
+    settings: Settings;
 }
 
 export class DownloadTemplateUseCase implements UseCase {
@@ -46,6 +48,7 @@ export class DownloadTemplateUseCase implements UseCase {
             populateStartDate,
             populateEndDate,
             writeFile,
+            settings,
         }: DownloadTemplateProps
     ): Promise<void> {
         const { id: templateId } = getTemplateId(type, id);
@@ -72,6 +75,7 @@ export class DownloadTemplateUseCase implements UseCase {
                 language,
                 theme,
                 template,
+                settings,
             });
             const workbook = await sheetBuilder.generate();
 

--- a/src/webapp/components/settings/DataElementItem.ts
+++ b/src/webapp/components/settings/DataElementItem.ts
@@ -42,7 +42,11 @@ export function getDataElementDisaggregatedFromItem(de: DataElementItem): DataEl
 }
 
 export function getMultiSelectorDataElementOptions(dataElements: DataElementItem[]): DataElementOption[] {
-    const options = dataElements.map(
+    const sortedDataElements = _(dataElements)
+        .orderBy([item => item.name, item => (item.categoryOptionCombo ? 1 : 0)], ["asc", "asc"])
+        .value();
+
+    return sortedDataElements.map(
         (item): DataElementOption => {
             const dataElementDis = getDataElementDisaggregatedFromItem(item);
             const coc = item.categoryOptionCombo;
@@ -53,6 +57,4 @@ export function getMultiSelectorDataElementOptions(dataElements: DataElementItem
             return { value: getDataElementDisaggregatedId(dataElementDis), text };
         }
     );
-
-    return _.sortBy(options, option => option.text);
 }

--- a/src/webapp/components/settings/DataElementItem.ts
+++ b/src/webapp/components/settings/DataElementItem.ts
@@ -1,0 +1,60 @@
+import _ from "lodash";
+import {
+    DataElementDisaggregated,
+    DataElementDisaggregatedId,
+    getDataElementDisaggregatedId,
+} from "../../../domain/entities/DataElementDisaggregated";
+import { DataForm } from "../../../domain/entities/DataForm";
+import { NamedRef } from "../../../domain/entities/ReferenceObject";
+import i18n from "../../../locales";
+
+type DataSet = DataForm;
+
+export interface DataElementItem {
+    id: string;
+    name: string;
+    hasDefaultDisaggregation: boolean;
+    categoryOptionCombo?: NamedRef;
+}
+
+export interface DataElementOption {
+    value: DataElementDisaggregatedId;
+    text: string;
+}
+
+export function getDataElementItems(dataSet: DataSet | undefined): DataElementItem[] {
+    const dataElements = dataSet ? dataSet.dataElements : [];
+
+    return _.flatMap(dataElements, dataElement => {
+        const categoryOptionCombos = dataElement.categoryOptionCombos || [];
+        const hasDefaultDisaggregation =
+            categoryOptionCombos.length === 1 && categoryOptionCombos[0]?.name === "default";
+        const mainDataElement: DataElementItem = { ...dataElement, hasDefaultDisaggregation };
+        const disaggregatedDataElements: DataElementItem[] = _(categoryOptionCombos)
+            .map(coc => ({ ...dataElement, categoryOptionCombo: coc, hasDefaultDisaggregation }))
+            .sortBy(de => de.categoryOptionCombo.name)
+            .value();
+
+        return [mainDataElement, ...(hasDefaultDisaggregation ? [] : disaggregatedDataElements)];
+    });
+}
+
+export function getDataElementDisaggregatedFromItem(de: DataElementItem): DataElementDisaggregated {
+    const categoryOptionCombo = de.categoryOptionCombo;
+    return categoryOptionCombo ? { id: de.id, categoryOptionComboId: categoryOptionCombo.id } : { id: de.id };
+}
+
+export function getMultiSelectorDataElementOptions(dataElements: DataElementItem[]): DataElementOption[] {
+    const options = dataElements.map(
+        (item): DataElementOption => {
+            const dataElementDis = getDataElementDisaggregatedFromItem(item);
+            const text = !item.categoryOptionCombo
+                ? item.name + (item.hasDefaultDisaggregation ? "" : ` (${i18n.t("All")})`)
+                : `${item.name} (${item.categoryOptionCombo.name})`;
+
+            return { value: getDataElementDisaggregatedId(dataElementDis), text };
+        }
+    );
+
+    return _.sortBy(options, option => option.text);
+}

--- a/src/webapp/components/settings/DataSetDataElementsFilterDialog.tsx
+++ b/src/webapp/components/settings/DataSetDataElementsFilterDialog.tsx
@@ -86,6 +86,7 @@ export function DataSetDataElementsFilterDialog(props: DataSetDataElementsFilter
             <div className={classes.row}>
                 <MultiSelector
                     d2={d2}
+                    searchFilterLabel={i18n.t("Search data elements")}
                     height={300}
                     onChange={updateSelection}
                     options={dataElementsOptions}

--- a/src/webapp/components/settings/DataSetDataElementsFilterDialog.tsx
+++ b/src/webapp/components/settings/DataSetDataElementsFilterDialog.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import _ from "lodash";
+import { ConfirmationDialog, MultiSelector } from "@eyeseetea/d2-ui-components";
+import { makeStyles } from "@material-ui/core";
+
+import i18n from "../../../locales";
+import { Select, SelectOption } from "../select/Select";
+import { SettingsFieldsProps } from "./SettingsFields";
+import { useAppContext } from "../../contexts/app-context";
+import { DataForm } from "../../../domain/entities/DataForm";
+import { NamedRef } from "../../../domain/entities/ReferenceObject";
+import {
+    DataElementDisaggregatedId,
+    getDataElementDisaggregatedId,
+} from "../../../domain/entities/DataElementDisaggregated";
+import {
+    getMultiSelectorDataElementOptions as getDataElementOptions,
+    getDataElementItems,
+    DataElementOption,
+    getDataElementDisaggregatedFromItem,
+} from "./DataElementItem";
+import Settings from "../../logic/settings";
+
+export interface DataSetDataElementsFilterDialogProps extends SettingsFieldsProps {
+    title: string;
+    onClose: () => void;
+}
+
+export function DataSetDataElementsFilterDialog(props: DataSetDataElementsFilterDialogProps): React.ReactElement {
+    const { title, onClose, settings, onChange } = props;
+    const { d2, compositionRoot } = useAppContext();
+    const classes = useStyles();
+
+    const [dataSets, setDataSets] = React.useState<DataForm[]>([]);
+    const [dataSet, setDataSet] = React.useState<DataForm>();
+
+    React.useEffect(() => {
+        compositionRoot.templates.list().then(({ dataSets }) => {
+            setDataSets(dataSets);
+        });
+    }, [compositionRoot]);
+
+    const selectDataSet = React.useCallback(
+        ({ value }: SelectOption) => {
+            setDataSet(dataSets.find(dataSet => dataSet.id === value));
+        },
+        [dataSets]
+    );
+
+    const dataSetsOptions = React.useMemo(() => getSelectOptionsFromNamedRefs(dataSets), [dataSets]);
+    const dataElementItems = React.useMemo(() => getDataElementItems(dataSet), [dataSet]);
+    const dataElementsOptions = React.useMemo(() => getDataElementOptions(dataElementItems), [dataElementItems]);
+    const selectedIds = getSelectedIds(settings, dataSet, dataElementsOptions);
+
+    const updateSelection = React.useCallback(
+        (newSelectedIds: DataElementDisaggregatedId[]) => {
+            const newSettings = settings.setDataSetDataElementsFilterFromSelection({
+                dataSet,
+                dataElementsDisaggregated: dataElementItems.map(getDataElementDisaggregatedFromItem),
+                prevSelectedIds: selectedIds,
+                newSelectedIds,
+            });
+            onChange(newSettings);
+        },
+        [selectedIds, dataSet, settings, dataElementItems, onChange]
+    );
+
+    return (
+        <ConfirmationDialog
+            isOpen={true}
+            title={title}
+            maxWidth="lg"
+            fullWidth={true}
+            onCancel={onClose}
+            cancelText={i18n.t("Close")}
+        >
+            <div className={classes.row}>
+                <Select
+                    placeholder={i18n.t("Data set")}
+                    options={dataSetsOptions}
+                    onChange={selectDataSet}
+                    value={dataSet?.id ?? ""}
+                />
+            </div>
+
+            <div className={classes.row}>
+                <MultiSelector
+                    d2={d2}
+                    height={300}
+                    onChange={updateSelection}
+                    options={dataElementsOptions}
+                    selected={selectedIds}
+                />
+            </div>
+        </ConfirmationDialog>
+    );
+}
+
+const useStyles = makeStyles({
+    row: { width: "100%", marginBottom: "2em" },
+});
+
+function getSelectOptionsFromNamedRefs<Model extends NamedRef>(models: Model[]): SelectOption[] {
+    return models.map(({ id, name }) => ({ value: id, label: name }));
+}
+
+function getSelectedIds(settings: Settings, dataSet: DataForm | undefined, dataElementsOptions: DataElementOption[]) {
+    if (!dataSet) return [];
+
+    const allOptionIds = dataElementsOptions.map(option => option.value);
+
+    const excludedIds: string[] = dataSet
+        ? (settings.dataSetDataElementsFilter[dataSet.id] || []).map(getDataElementDisaggregatedId)
+        : [];
+
+    return _.difference(allOptionIds, excludedIds);
+}

--- a/src/webapp/components/settings/SettingsFields.tsx
+++ b/src/webapp/components/settings/SettingsFields.tsx
@@ -17,6 +17,7 @@ import Settings, { PermissionSetting } from "../../logic/settings";
 import { Select, SelectOption } from "../select/Select";
 import DataElementsFilterDialog from "./DataElementsFilterDialog";
 import PermissionsDialog from "./PermissionsDialog";
+import { DataSetDataElementsFilterDialog } from "./DataSetDataElementsFilterDialog";
 
 export interface SettingsFieldsProps {
     settings: Settings;
@@ -28,6 +29,7 @@ export default function SettingsFields({ settings, onChange }: SettingsFieldsPro
 
     const [permissionsType, setPermissionsType] = useState<PermissionSetting | null>(null);
     const [isExclusionDialogVisible, showExclusionDialog] = useState<boolean>(false);
+    const [isDataSetDataElementsDialogVisible, showDataSetDataElementsDialog] = useState<boolean>(false);
 
     const setModel = useCallback(
         (model: Model) => {
@@ -145,6 +147,14 @@ export default function SettingsFields({ settings, onChange }: SettingsFieldsPro
 
     return (
         <React.Fragment>
+            {isDataSetDataElementsDialogVisible && (
+                <DataSetDataElementsFilterDialog
+                    title={i18n.t("Data elements filter for data sets")}
+                    onClose={() => showDataSetDataElementsDialog(false)}
+                    settings={settings}
+                    onChange={onChange}
+                />
+            )}
             {!!isExclusionDialogVisible && (
                 <DataElementsFilterDialog
                     onClose={() => showExclusionDialog(false)}
@@ -185,6 +195,23 @@ export default function SettingsFields({ settings, onChange }: SettingsFieldsPro
                     />
                 </div>
             </FormGroup>
+
+            <h3 className={classes.title}>{i18n.t("Columns layout")}</h3>
+
+            <div className={classes.content}>
+                <ListItem button onClick={() => showDataSetDataElementsDialog(true)}>
+                    <ListItemIcon>
+                        <Icon>filter_list</Icon>
+                    </ListItemIcon>
+
+                    <ListItemText
+                        primary={i18n.t("Data elements filter for data sets")}
+                        secondary={i18n.t(
+                            "Data elements (with optional disaggregation) to include/exclude for data sets"
+                        )}
+                    />
+                </ListItem>
+            </div>
 
             <h3 className={classes.title}>{i18n.t("Duplicate detection")}</h3>
 

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -53,6 +53,7 @@ export const TemplateSelector = ({ settings, themes, onChange }: TemplateSelecto
         endDate: moment().add("-1", "year").endOf("year"),
         populate: false,
         language: "en",
+        settings,
     });
 
     const models = useMemo(() => {

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -555,14 +555,13 @@ SheetBuilder.prototype.fillDataEntrySheet = function () {
             const firstColumnId = columnId;
 
             _.forEach(categoryOptionCombos, categoryOptionCombo => {
-                const isColumnExcluded = _(dataElementsExclusion)
-                    .get(dataSet.id, [])
-                    .some(dataElementExcluded =>
-                        _.isEqual(dataElementExcluded, {
-                            id: dataElement.id,
-                            categoryOptionComboId: categoryOptionCombo.id,
-                        })
-                    );
+                const dataElementsExcluded = _.get(dataElementsExclusion, dataSet.id, []);
+                const isColumnExcluded = _.some(dataElementsExcluded, dataElementExcluded =>
+                    _.isEqual(dataElementExcluded, {
+                        id: dataElement.id,
+                        categoryOptionComboId: categoryOptionCombo.id,
+                    })
+                );
                 if (isColumnExcluded) return;
 
                 const validation = dataElement.optionSet ? dataElement.optionSet.id : dataElement.valueType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,17 +1466,22 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@date-io/core@1.x", "@date-io/core@^1.3.13", "@date-io/core@^1.3.6":
+"@date-io/core@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.npmjs.org/@date-io/core/-/core-1.3.6.tgz#5c518cee6fa011e754293aebc6f1192360061797"
+  integrity sha512-cihiu8YaTHh7IqrzekbZcA7dh+7uhViHgWyxcKAO2cg1DYGYC5J7z4/rnGGL7swrK5xFVLIeyoxJ+sacziIRKg==
+
+"@date-io/core@1.x", "@date-io/core@^1.0.2":
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/moment@^1.0.2":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
-  integrity sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==
+"@date-io/moment@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@date-io/moment/-/moment-1.0.2.tgz#898ca98d2031376cfed3c7258a8078a26892a501"
+  integrity sha512-iQFRMH49cFYH/jzgYhdvmO+YfLRmsBZX293Vcfrvkfk+ovrd2g5KOtP5Je3CBlywfqNOQlCC3tKAxsIvaIDSYw==
   dependencies:
-    "@date-io/core" "^1.3.13"
+    "@date-io/core" "^1.0.2"
 
 "@dhis2/app-runtime@2.2.2":
   version "2.2.2"
@@ -1590,24 +1595,24 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-ui-components@2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-ui-components/-/d2-ui-components-2.5.2.tgz#febf1644481a68e55d03aec0076a2ff67f90cd15"
-  integrity sha512-r7esgwLrCuMU5c5hIfHA2C4GDDrD3EpUc4U6kgsDNApSUwCT6QU4+YKHe1Tgy8FgKg1woXVmxYzD7MYgM7GyWw==
+"@eyeseetea/d2-ui-components@2.6.3-beta.2":
+  version "2.6.3-beta.2"
+  resolved "https://registry.npmjs.org/@eyeseetea/d2-ui-components/-/d2-ui-components-2.6.3-beta.2.tgz#0c7f4e8f1a61f8c269e055d67f0f38d93a4891e5"
+  integrity sha512-VbVsCB7sTogcMAdy0FJdCv39YqtU0819sKRed7+/v8xEk6UAd9jX3CdWX0Bc6m/HsVoWIhdJvd3rpWC2JYK0ag==
   dependencies:
-    "@date-io/core" "^1.3.6"
-    "@date-io/moment" "^1.0.2"
+    "@date-io/core" "1.3.6"
+    "@date-io/moment" "1.0.2"
     "@dhis2/d2-i18n" "1.0.6"
     "@dhis2/d2-ui-core" "6.3.0"
     "@material-ui/pickers" "3.2.10"
-    classnames "^2.2.6"
-    downshift "^5.4.2"
-    lodash "4.17.19"
-    moment "^2.22.2"
-    nano-memoize "1.1.10"
-    react-linkify "^1.0.0-alpha"
-    rxjs-compat "6.5.4"
-    throttle-debounce "^2.1.0"
+    classnames "2.2.6"
+    downshift "5.4.2"
+    lodash "4.17.20"
+    moment "2.22.2"
+    nano-memoize "1.2.1"
+    react-linkify "1.0.0-alpha"
+    rxjs-compat "6.6.3"
+    throttle-debounce "2.1.0"
 
 "@eyeseetea/xlsx-populate@4.1.0":
   version "4.1.0"
@@ -4527,7 +4532,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
+classnames@2.2.6, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5907,9 +5912,9 @@ dotenv@8.2.0, dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
-downshift@^5.4.2:
+downshift@5.4.2:
   version "5.4.2"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.4.2.tgz#3f6b7bf4ad7e0ff5503414efe3a398421763ebae"
+  resolved "https://registry.npmjs.org/downshift/-/downshift-5.4.2.tgz#3f6b7bf4ad7e0ff5503414efe3a398421763ebae"
   integrity sha512-IVwIc4iw5OF5Bi/MbITarW2E8/5akm++5b6UL7aXyPoZmuVe4ilFGaQaktdFW/IwuzHieIwaWj4AQgI0lQNslQ==
   dependencies:
     "@babel/runtime" "^7.9.1"
@@ -9778,11 +9783,6 @@ lodash.uniqueid@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
   integrity sha1-MmjyanyI5PSxdY1nknGBTjH6WyY=
 
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
 lodash@4.17.20, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -10230,12 +10230,17 @@ moment-timezone@^0.5.25:
   dependencies:
     moment ">= 2.9.0"
 
+moment@2.22.2:
+  version "2.22.2"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
+
 moment@2.29.1, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
-"moment@>= 2.9.0", moment@^2.22.1, moment@^2.22.2, moment@^2.24.0:
+"moment@>= 2.9.0", moment@^2.22.1, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -10285,10 +10290,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nano-memoize@1.1.10:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/nano-memoize/-/nano-memoize-1.1.10.tgz#ff38d9454812f7c5a5248b7115c838ab4da936c5"
-  integrity sha512-eMG3EMNCZ64XP7EMrCr0dBVuQPj1htR7nx81/vGYWy1GP/Waw+CqwScswwooKUQD16KnuJI2zUZCwdwC1Lki3w==
+nano-memoize@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/nano-memoize/-/nano-memoize-1.2.1.tgz#21091318021c81374a525349a8cd0ad712122077"
+  integrity sha512-ANfJ0QFhLzv9BZV8tHxwaDClqr+U8yY65hZA+slbgJrx+ePnHtlY92F2ZJInkkQWUUR71NzCEHBshKCHJnNyaQ==
 
 nanoid@^3.1.20:
   version "3.1.20"
@@ -12290,9 +12295,9 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-linkify@^1.0.0-alpha:
+react-linkify@1.0.0-alpha:
   version "1.0.0-alpha"
-  resolved "https://registry.yarnpkg.com/react-linkify/-/react-linkify-1.0.0-alpha.tgz#b391c7b88e3443752fafe76a95ca4434e82e70d5"
+  resolved "https://registry.npmjs.org/react-linkify/-/react-linkify-1.0.0-alpha.tgz#b391c7b88e3443752fafe76a95ca4434e82e70d5"
   integrity sha512-7gcIUvJkAXXttt1fmBK9cwn+1jTa4hbKLGCZ9J1U6EOkyb2/+LKL1Z28d9rtDLMnpvImlNlLPdTPooorl5cpmg==
   dependencies:
     linkify-it "^2.0.3"
@@ -13026,10 +13031,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs-compat@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs-compat/-/rxjs-compat-6.5.4.tgz#03825692af3fe363e04c43f41ff4113d76bbd305"
-  integrity sha512-rkn+lbOHUQOurdd74J/hjmDsG9nFx0z66fvnbs8M95nrtKvNqCKdk7iZqdY51CGmDemTQk+kUPy4s8HVOHtkfA==
+rxjs-compat@6.6.3:
+  version "6.6.3"
+  resolved "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.3.tgz#141405fcee11f48718d428b99c8f01826f594e5c"
+  integrity sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw==
 
 rxjs@^5.5.7:
   version "5.5.12"
@@ -14189,9 +14194,9 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-throttle-debounce@^2.1.0:
+throttle-debounce@2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
 throttleit@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-ui-components@2.6.3-beta.2":
-  version "2.6.3-beta.2"
-  resolved "https://registry.npmjs.org/@eyeseetea/d2-ui-components/-/d2-ui-components-2.6.3-beta.2.tgz#0c7f4e8f1a61f8c269e055d67f0f38d93a4891e5"
-  integrity sha512-VbVsCB7sTogcMAdy0FJdCv39YqtU0819sKRed7+/v8xEk6UAd9jX3CdWX0Bc6m/HsVoWIhdJvd3rpWC2JYK0ag==
+"@eyeseetea/d2-ui-components@2.6.3":
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-ui-components/-/d2-ui-components-2.6.3.tgz#707dea134040759792616f0535132dd9a450ae79"
+  integrity sha512-AyXESkwdedjFAY2Ob1Qh+sVDNC572uo0drwCkJFEZIRBfqbn6tyrDXzmtZJkWXW7cwvvzQr2PET+d1bqaqDviQ==
   dependencies:
     "@date-io/core" "1.3.6"
     "@date-io/moment" "1.0.2"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes: 
  https://app.clickup.com/t/gd0mvn
  https://app.clickup.com/t/gd0efp

Uses d2-ui-components beta: https://github.com/EyeSeeTea/d2-ui-components/pull/206

### :memo: Implementation

- Use dataSet sections:
  - Branch logic: `const useDataSetSections = dataSet.formType === "SECTION" || !_(dataSet.sections).isEmpty();`
  - `getDataElementsForSectionDataSet` refactored to use `dataSet.sections[].dataElements` and then the missing `dataSet.dataSetElements[].dataElement`. Note that previously only dataElements in sections where used.
 
- Data Set -> Data elements filter: Using new property in settings:  
```
    "dataSetDataElementsFilter": {
        "WxZRmtj4tr0": [
            {
                "id": "awsNtaiPxBR",
                "categoryOptionComboId": "ivixWPWcOto"
            }
        ]
    }
```

