### PR TITLE
Export tracker programs with stage/relationship sheet names validated

### DIFF
--- a/src/data/templates/generated-tracker-program/TrackerProgramGenerated.01.ts
+++ b/src/data/templates/generated-tracker-program/TrackerProgramGenerated.01.ts
@@ -139,9 +139,9 @@ export class TrackerProgramGenerated01 implements GeneratedTemplate {
 }
 
 function isStageSheet(name: string): boolean {
-    return name.startsWith("(");
+    return name.startsWith("Stage") || name.startsWith("(");
 }
 
 function isRelationshipSheet(name: string): boolean {
-    return name.startsWith("Relationship");
+    return name.startsWith("Rel");
 }

--- a/src/data/templates/generated-tracker-program/TrackerProgramGenerated.01.ts
+++ b/src/data/templates/generated-tracker-program/TrackerProgramGenerated.01.ts
@@ -139,7 +139,7 @@ export class TrackerProgramGenerated01 implements GeneratedTemplate {
 }
 
 function isStageSheet(name: string): boolean {
-    return name.startsWith("Stage");
+    return name.startsWith("(");
 }
 
 function isRelationshipSheet(name: string): boolean {

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -41,7 +41,7 @@ SheetBuilder.prototype.generate = function () {
         });
 
         // RelationshipType sheets
-        withSheetNames(builder.metadata.relationshipTypes, { prefix: "Relationship" }).forEach(relationshipType => {
+        withSheetNames(builder.metadata.relationshipTypes, { prefix: "Rel" }).forEach(relationshipType => {
             const sheet = this.workbook.addWorksheet(relationshipType.sheetName);
             this.relationshipsSheets.push([relationshipType, sheet]);
         });
@@ -963,7 +963,7 @@ function withSheetNames(objs, options = {}) {
     return objs.filter(Boolean).map((obj, idx) => {
         const baseSheetName = _([prefix, `(${idx + 1}) ${obj.name}`])
             .compact()
-            .join(" - ");
+            .join(" ");
 
         return {
             ...obj,

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -35,13 +35,13 @@ SheetBuilder.prototype.generate = function () {
         // ProgramStage sheets
         const programStages = element.programStages.map(programStageT => metadata.get(programStageT.id));
 
-        withSheetNames(programStages, "Stage").forEach(programStage => {
+        withSheetNames(programStages).forEach(programStage => {
             const sheet = this.workbook.addWorksheet(programStage.sheetName);
             this.programStageSheets[programStage.id] = sheet;
         });
 
         // RelationshipType sheets
-        withSheetNames(builder.metadata.relationshipTypes, "Relationship").forEach(relationshipType => {
+        withSheetNames(builder.metadata.relationshipTypes, { prefix: "Relationship" }).forEach(relationshipType => {
             const sheet = this.workbook.addWorksheet(relationshipType.sheetName);
             this.relationshipsSheets.push([relationshipType, sheet]);
         });
@@ -957,11 +957,17 @@ function getValidSheetName(name: string, maxLength = 31): string {
 }
 
 /* Add prop 'sheetName' with a valid sheet name to an array of objects having a string property 'name' */
-function withSheetNames(objs, prefix) {
+function withSheetNames(objs, options = {}) {
+    const { prefix } = options;
+
     return objs.filter(Boolean).map((obj, idx) => {
+        const baseSheetName = _([prefix, `(${idx + 1}) ${obj.name}`])
+            .compact()
+            .join(" - ");
+
         return {
             ...obj,
-            sheetName: getValidSheetName(`${prefix} - ${idx + 1}-${obj.name}`),
+            sheetName: getValidSheetName(baseSheetName),
         };
     });
 }

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -32,14 +32,17 @@ SheetBuilder.prototype.generate = function () {
         this.programStageSheets = {};
         this.relationshipsSheets = [];
 
-        _.forEach(element.programStages, programStageT => {
-            const programStage = metadata.get(programStageT.id);
-            const sheet = this.workbook.addWorksheet(`Stage - ${programStage.name}`);
-            this.programStageSheets[programStageT.id] = sheet;
+        // ProgramStage sheets
+        const programStages = element.programStages.map(programStageT => metadata.get(programStageT.id));
+
+        withSheetNames(programStages, "Stage").forEach(programStage => {
+            const sheet = this.workbook.addWorksheet(programStage.sheetName);
+            this.programStageSheets[programStage.id] = sheet;
         });
 
-        _.forEach(builder.metadata.relationshipTypes, relationshipType => {
-            const sheet = this.workbook.addWorksheet(`Relationship - ${relationshipType.name}`);
+        // RelationshipType sheets
+        withSheetNames(builder.metadata.relationshipTypes, "Relationship").forEach(relationshipType => {
+            const sheet = this.workbook.addWorksheet(relationshipType.sheetName);
             this.relationshipsSheets.push([relationshipType, sheet]);
         });
     } else {
@@ -945,4 +948,20 @@ export function getTemplateId(type, id) {
 
 function getRelationshipTypeKey(relationshipType, key) {
     return ["relationshipType", relationshipType.id, key].join("-");
+}
+
+function getValidSheetName(name: string, maxLength = 31): string {
+    // Invalid chars: \ / * ? : [ ]
+    // Maximum length: 31
+    return name.replace(/[\\/*?:[\]]/g, "").slice(0, maxLength);
+}
+
+/* Add prop 'sheetName' with a valid sheet name to an array of objects having a string property 'name' */
+function withSheetNames(objs, prefix) {
+    return objs.filter(Boolean).map((obj, idx) => {
+        return {
+            ...obj,
+            sheetName: getValidSheetName(`${prefix} - ${idx + 1}-${obj.name}`),
+        };
+    });
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/gd66jv, https://app.clickup.com/t/g56eey

### :memo: Implementation

- For program stages and relationship types, we now do, for example program stage: `Stage - 1-Valid Name of program stage`. This way we enforce a valid name and uniqueness. I think it's also handy to see the index of the tabs when you have many.

Tested with Excel 2019, COVID-19 RDT User experience, now the file opens without any warning.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/113132208-6e2c4000-921e-11eb-9829-57040c501f93.png)
