### PR TITLE
COVID-19 refinement. Tracker fixes and improvements

### DIFF
--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -248,9 +248,15 @@ export class ExcelBuilder {
 
         const dataElementIdsSet = new Set(dataElementIds);
 
-        for (const { id, period, dataValues, trackedEntityInstance, attribute: cocId } of payload.dataEntries) {
+        for (const dataEntry of payload.dataEntries) {
+            const { id, period, dataValues, trackedEntityInstance, attribute: cocId, programStage } = dataEntry;
             const someDataElementPresentInSheet = _(dataValues).some(dv => dataElementIdsSet.has(dv.dataElement));
             if (!someDataElementPresentInSheet) continue;
+
+            const dataSourceProgramStageId = await this.readCellValue(template, dataSource.programStage);
+            const eventBelongsToCurrentProgramStage =
+                dataSourceProgramStageId && dataSourceProgramStageId === programStage;
+            if (!eventBelongsToCurrentProgramStage) continue;
 
             const cells = await this.excelRepository.getCellsInRange(template.id, {
                 ...dataSource.dataValues,

--- a/src/webapp/logic/dhisConnector.js
+++ b/src/webapp/logic/dhisConnector.js
@@ -14,7 +14,7 @@ export async function getElement(api, type, id) {
         "formType",
         "sections[id,sortOrder,dataElements[id]]",
         "periodType",
-        "programStages",
+        "programStages[id,access]",
         "programType",
         "enrollmentDateLabel",
         "incidentDateLabel",

--- a/src/webapp/logic/sheetBuilder.js
+++ b/src/webapp/logic/sheetBuilder.js
@@ -386,7 +386,7 @@ SheetBuilder.prototype.fillValidationSheet = function () {
 };
 
 SheetBuilder.prototype.fillMetadataSheet = function () {
-    const { elementMetadata: metadata, organisationUnits, element } = this.builder;
+    const { elementMetadata: metadata, organisationUnits } = this.builder;
     const metadataSheet = this.metadataSheet;
 
     // Freeze and format column titles
@@ -412,15 +412,7 @@ SheetBuilder.prototype.fillMetadataSheet = function () {
             ?.map(({ id }) => metadata.get(id))
             .map(option => this.translate(option).name)
             .join(", ");
-
-        const isProgramStageDataElementCompulsory = _.some(
-            this.builder.rawMetadata.programStageDataElements,
-            ({ dataElement, compulsory }) => dataElement.id === item.id && compulsory
-        );
-
-        const isProgram = element.type === "programs" || isTrackerProgram(element);
-
-        const isCompulsory = isProgramStageDataElementCompulsory || (isProgram && item.type === "categoryCombos");
+        const isCompulsory = this.isMetadataItemCompulsory(item);
 
         metadataSheet.cell(rowId, 1).string(item.id ?? "");
         metadataSheet.cell(rowId, 2).string(item.type ?? "");
@@ -486,6 +478,25 @@ SheetBuilder.prototype.fillMetadataSheet = function () {
         name: "_false",
     });
     rowId++;
+};
+
+SheetBuilder.prototype.isMetadataItemCompulsory = function (item) {
+    const { rawMetadata, element } = this.builder;
+
+    const isProgramStageDataElementCompulsory = _.some(
+        rawMetadata.programStageDataElements,
+        ({ dataElement, compulsory }) => dataElement?.id === item.id && compulsory
+    );
+
+    const isTeiAttributeCompulsory = _.some(
+        rawMetadata.programTrackedEntityAttributes,
+        ({ trackedEntityAttribute, mandatory }) => trackedEntityAttribute?.id === item.id && mandatory
+    );
+
+    const isProgram = element.type === "programs" || isTrackerProgram(element);
+    const isCategoryComboForProgram = isProgram && item.type === "categoryCombos";
+
+    return isProgramStageDataElementCompulsory || isTeiAttributeCompulsory || isCategoryComboForProgram;
 };
 
 SheetBuilder.prototype.getVersion = function () {


### PR DESCRIPTION
### :pushpin: References

Fixes:
Original issues created during the testing: https://app.clickup.com/t/gq7a4t

https://app.clickup.com/t/g709ua
https://app.clickup.com/t/g70a2w
https://app.clickup.com/t/h38v8p
https://app.clickup.com/t/h151jj
https://app.clickup.com/t/h56h73

### :memo: Implementation


#### https://app.clickup.com/t/h38v8p
> Some events are split in two (creating a sort of duplication) - See RDT User experience (28) excel file below

Some of the data elements belong to multiple program stages. For example, "Occupation" and "Other occupation" in the first and second tab. So, when exporting, you see the events for these data elements in both tabs. See COVID-19 RDT User experience (28)-exported.xlsx -> Now we match event.programStage with the current program stage sheet.

#### https://app.clickup.com/t/h56h73
> When importing the Case Surveillance with test user, we get a "TEI not enrolled" although it looks like the TEI was properly imported - See Case-based Surveillance (17) excel file below

The problem was that, in fact, the TEI was not being saved. But the response was "SUCCESS" The problem was that the response had a global "SUCCESS" but an inner import summary (enrollment) had failed (the required attribute "Sex" was not set) . So now we use the main + enrollment summary to 1) get error messages, 2) get the aggregated status. And now the error is displayed, and the POST stops there.

#### https://app.clickup.com/t/g709ua

Check mandatory property

#### https://app.clickup.com/t/g70a2w

Get extra info for program: `programStage[id,access]` and check `access.read && access.data.read && access.data.write`

#### https://app.clickup.com/t/h151jj

Add link to data element label with URL field