### PR TITLE
Format in column header for dataElements of type date

### DIFF
--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -22,6 +22,12 @@ const maxRow = 1048576;
 // Excel shows all empty rows, limit the maximum number of TEIs
 const maxTeiRows = 1024;
 
+const dateFormats: Record<string, string> = {
+    DATE: "YYYY-MM-DD",
+    TIME: "HH:mm",
+    DATETIME: "YYYY-MM-DDTHH:mm",
+};
+
 export interface SheetBuilderParams {
     element: any;
     metadata: any;
@@ -611,10 +617,16 @@ export class SheetBuilder {
                 .map(({ id }: any) => this.translate(metadata.get(id)).name)
                 .join(", ");
             const isCompulsory = this.isMetadataItemCompulsory(item);
+            const dateFormat = dateFormats[item.valueType];
+            const nameCellValue = _.compact([
+                name,
+                isCompulsory ? " *" : "",
+                dateFormat ? `\n(${dateFormat})` : "",
+            ]).join("");
 
             metadataSheet.cell(rowId, 1).string(item.id ?? "");
             metadataSheet.cell(rowId, 2).string(item.type ?? "");
-            metadataSheet.cell(rowId, 3).string(name?.concat(isCompulsory ? " *" : "") ?? "");
+            metadataSheet.cell(rowId, 3).string(nameCellValue);
             metadataSheet.cell(rowId, 4).string(item.valueType ?? "");
             metadataSheet.cell(rowId, 5).string(optionSetName ?? "");
             metadataSheet.cell(rowId, 6).string(options ?? "");


### PR DESCRIPTION


### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/1ej5mw0

### :memo: Implementation

- Show for types: `"DATE",  `"TIME"`, `"DATETIME"`.
- Line added to the sheet `Metadata`, which is used as a defined name in sheet `Data Entry`

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/135830708-d94f5c85-9807-4f31-8a02-e58fd29b3c56.png)