### PR TITLE
[Tracker programs] Add new geometry column (trackedEntityType.featureType)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-01-18T07:49:40.090Z\n"
-"PO-Revision-Date: 2022-01-18T07:49:40.090Z\n"
+"POT-Creation-Date: 2022-01-28T13:06:20.912Z\n"
+"PO-Revision-Date: 2022-01-28T13:06:20.912Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -525,6 +525,15 @@ msgid "Longitude"
 msgstr ""
 
 msgid "Invalid choice was chosen"
+msgstr ""
+
+msgid "No geometry"
+msgstr ""
+
+msgid "Point in map"
+msgstr ""
+
+msgid "Polygon in map"
 msgstr ""
 
 msgid "Home"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-01-18T07:49:40.090Z\n"
+"POT-Creation-Date: 2022-01-28T13:06:20.912Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -553,6 +553,15 @@ msgstr "Longitud"
 
 msgid "Invalid choice was chosen"
 msgstr "Se ha elegido una opción no válida"
+
+msgid "No geometry"
+msgstr ""
+
+msgid "Point in map"
+msgstr ""
+
+msgid "Polygon in map"
+msgstr ""
 
 msgid "Home"
 msgstr "Inicio"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2022-01-18T07:49:40.090Z\n"
+"POT-Creation-Date: 2022-01-28T13:06:20.912Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -530,6 +530,15 @@ msgid "Longitude"
 msgstr ""
 
 msgid "Invalid choice was chosen"
+msgstr ""
+
+msgid "No geometry"
+msgstr ""
+
+msgid "Point in map"
+msgstr ""
+
+msgid "Polygon in map"
 msgstr ""
 
 msgid "Home"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-01-18T07:49:40.090Z\n"
+"POT-Creation-Date: 2022-01-28T13:06:20.912Z\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -552,6 +552,15 @@ msgstr "Longitude"
 
 msgid "Invalid choice was chosen"
 msgstr "Esta opção é invalida"
+
+msgid "No geometry"
+msgstr ""
+
+msgid "Point in map"
+msgstr ""
+
+msgid "Polygon in map"
+msgstr ""
 
 msgid "Home"
 msgstr "Início"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-01-18T07:49:40.090Z\n"
+"POT-Creation-Date: 2022-01-28T13:06:20.912Z\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -554,6 +554,15 @@ msgstr "Долгота"
 
 msgid "Invalid choice was chosen"
 msgstr "Был выбран неправильный вариант"
+
+msgid "No geometry"
+msgstr ""
+
+msgid "Point in map"
+msgstr ""
+
+msgid "Polygon in map"
+msgstr ""
 
 msgid "Home"
 msgstr "Главная"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.3.3",
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
-        "@eyeseetea/d2-api": "1.10.0",
+        "@eyeseetea/d2-api": "1.10.2-beta.2",
         "@eyeseetea/d2-ui-components": "2.6.10",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.12.3",

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -91,8 +91,9 @@ export function fromApiRelationships(metadata: RelationshipMetadata, teiApi: Tra
                 getFromToRelationship(relationshipType, relApi.to, relApi.from);
 
             if (!fromToRelationship) {
-                const msg = `${relApi.from.trackedEntityInstance} -> ${relApi.to.trackedEntityInstance}`;
-                console.error(`No valid TEIs for relationship ${relApi.relationship}: ${msg}`);
+                const from = relApi.from.trackedEntityInstance?.trackedEntityInstance || "undefined";
+                const to = relApi.to.trackedEntityInstance?.trackedEntityInstance || "undefined";
+                console.error(`No valid TEIs for relationship ${relApi.relationship}: ${from} -> ${to}`);
                 return null;
             }
 

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -651,7 +651,7 @@ const formatDataElement = (de: SelectedPick<D2DataElementSchema, typeof dataElem
 type TrackedEntityTypeApi = Pick<D2TrackedEntityType, "id" | "featureType">;
 
 function getTrackedEntityTypeFromApi(trackedEntityType: TrackedEntityTypeApi): DataForm["trackedEntityType"] {
-    const ft = trackedEntityType.featureType;
-    const featureType = ft === "POINT" ? "point" : ft === "POLYGON" ? "polygon" : "none";
+    const d2FeatureType = trackedEntityType.featureType;
+    const featureType = d2FeatureType === "POINT" ? "point" : d2FeatureType === "POLYGON" ? "polygon" : "none";
     return { id: trackedEntityType.id, featureType };
 }

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -21,6 +21,7 @@ import {
     D2Api,
     D2ApiDefault,
     D2DataElementSchema,
+    D2TrackedEntityType,
     DataStore,
     DataValueSetsGetResponse,
     Id,
@@ -132,7 +133,7 @@ export class InstanceDhisRepository implements InstanceRepository {
                     id: trackedEntityAttribute.id,
                     name: trackedEntityAttribute.name,
                 })),
-                trackedEntityType,
+                trackedEntityType: getTrackedEntityTypeFromApi(trackedEntityType),
             })
         );
     }
@@ -636,7 +637,7 @@ const programFields = {
     programTrackedEntityAttributes: { trackedEntityAttribute: { id: true, name: true } },
     access: true,
     programType: true,
-    trackedEntityType: { id: true },
+    trackedEntityType: { id: true, featureType: true },
 } as const;
 
 const formatDataElement = (de: SelectedPick<D2DataElementSchema, typeof dataElementFields>): DataElement => ({
@@ -646,3 +647,11 @@ const formatDataElement = (de: SelectedPick<D2DataElementSchema, typeof dataElem
     categoryOptionCombos: de.categoryCombo?.categoryOptionCombos ?? [],
     options: de.optionSet?.options,
 });
+
+type TrackedEntityTypeApi = Pick<D2TrackedEntityType, "id" | "featureType">;
+
+function getTrackedEntityTypeFromApi(trackedEntityType: TrackedEntityTypeApi): DataForm["trackedEntityType"] {
+    const ft = trackedEntityType.featureType;
+    const featureType = ft === "POINT" ? "point" : ft === "POLYGON" ? "polygon" : "none";
+    return { id: trackedEntityType.id, featureType };
+}

--- a/src/data/templates/generated-tracker-program/TrackerProgramGenerated.03.ts
+++ b/src/data/templates/generated-tracker-program/TrackerProgramGenerated.03.ts
@@ -1,0 +1,152 @@
+import { DataSource, GeneratedTemplate, StyleSource } from "../../../domain/entities/Template";
+
+export class TrackerProgramGenerated03 implements GeneratedTemplate {
+    public readonly type = "generated";
+    public readonly id = "TRACKER_PROGRAM_GENERATED_v3";
+    public readonly name = "Auto-generated Tracker Program template";
+    public readonly dataFormId = { type: "cell" as const, sheet: "Validation", ref: "A1" };
+    public readonly dataFormType = { type: "value" as const, id: "trackerPrograms" as const };
+
+    public readonly rowOffset = 3;
+    public readonly colOffset = 0;
+
+    public readonly dataSources: DataSource[] = [
+        {
+            type: "rowTei",
+            teiId: {
+                sheet: "TEI Instances",
+                type: "column",
+                ref: "A",
+            },
+            orgUnit: {
+                sheet: "TEI Instances",
+                type: "column",
+                ref: "B",
+            },
+            geometry: {
+                sheet: "TEI Instances",
+                type: "column",
+                ref: "C",
+            },
+            enrollmentDate: {
+                sheet: "TEI Instances",
+                type: "column",
+                ref: "D",
+            },
+            incidentDate: {
+                sheet: "TEI Instances",
+                type: "column",
+                ref: "E",
+            },
+            attributes: {
+                sheet: "TEI Instances",
+                rowStart: 6,
+                columnStart: "F",
+            },
+            attributeId: {
+                sheet: "TEI Instances",
+                type: "row",
+                ref: 5,
+            },
+        },
+        (sheet: string) =>
+            isRelationshipSheet(sheet) && {
+                type: "rowTeiRelationship",
+                range: {
+                    sheet,
+                    rowStart: 3,
+                    columnStart: "A",
+                },
+                relationshipType: {
+                    sheet,
+                    type: "cell",
+                    ref: "A1",
+                },
+                from: {
+                    sheet,
+                    type: "column",
+                    ref: "A",
+                },
+                to: {
+                    sheet,
+                    type: "column",
+                    ref: "B",
+                },
+            },
+        (sheet: string) =>
+            isStageSheet(sheet) && {
+                type: "rowTrackedEvent",
+                eventId: {
+                    sheet,
+                    type: "column",
+                    ref: "A",
+                },
+                teiId: {
+                    sheet,
+                    type: "column",
+                    ref: "B",
+                },
+                categoryOptionCombo: {
+                    sheet,
+                    type: "column",
+                    ref: "C",
+                },
+                date: {
+                    sheet,
+                    type: "column",
+                    ref: "D",
+                },
+                programStage: {
+                    sheet,
+                    type: "cell",
+                    ref: "A1",
+                },
+                dataElements: {
+                    sheet,
+                    rowStart: 2,
+                    rowEnd: 2,
+                    columnStart: "E",
+                },
+                dataValues: {
+                    sheet,
+                    rowStart: 3,
+                    columnStart: "E",
+                },
+            },
+    ];
+
+    public readonly styleSources: StyleSource[] = [
+        {
+            section: "title",
+            source: {
+                type: "range",
+                ref: "D2:I2",
+                sheet: "TEI Instances",
+            },
+        },
+        {
+            section: "subtitle",
+            source: {
+                type: "range",
+                ref: "D3:I3",
+                sheet: "TEI Instances",
+            },
+        },
+        {
+            section: "logo",
+            source: {
+                type: "range",
+                ref: "A2:C3",
+                sheet: "TEI Instances",
+            },
+        },
+    ];
+}
+
+function isStageSheet(name: string): boolean {
+    return name.startsWith("Stage") || name.startsWith("(");
+}
+
+function isRelationshipSheet(name: string): boolean {
+    return name.startsWith("Rel");
+}

--- a/src/data/templates/index.ts
+++ b/src/data/templates/index.ts
@@ -10,6 +10,7 @@ export { ProgramGenerated04 } from "./generated-program/ProgramGenerated.04";
 
 export { TrackerProgramGenerated01 } from "./generated-tracker-program/TrackerProgramGenerated.01";
 export { TrackerProgramGenerated02 } from "./generated-tracker-program/TrackerProgramGenerated.02";
+export { TrackerProgramGenerated03 } from "./generated-tracker-program/TrackerProgramGenerated.03";
 
 export { NHWAModule101 } from "./nhwa-module-1/NHWAModule1.01";
 export { NHWAModule201 } from "./nhwa-module-2/NHWAModule2.01";

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -1,4 +1,4 @@
-import { Id, NamedRef, Ref } from "./ReferenceObject";
+import { Id, NamedRef } from "./ReferenceObject";
 
 export type DataFormType = "dataSets" | "programs" | "trackerPrograms";
 export type DataFormPeriod = "Daily" | "Monthly" | "Yearly" | "Weekly";
@@ -20,10 +20,17 @@ export interface DataForm {
         value: string;
     }[]; // Only used for versioning, is really being used by any client?
     teiAttributes?: NamedRef[];
-    trackedEntityType?: Ref;
+    trackedEntityType?: TrackedEntityType;
     readAccess: boolean;
     writeAccess: boolean;
 }
+
+export interface TrackedEntityType {
+    id: Id;
+    featureType: "none" | "point" | "polygon";
+}
+
+export type TrackedEntityTypeFeatureType = "none" | "point" | "polygon";
 
 export interface DataElement {
     id: Id;

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -27,7 +27,7 @@ export interface DataForm {
 
 export interface TrackedEntityType {
     id: Id;
-    featureType: "none" | "point" | "polygon";
+    featureType: TrackedEntityTypeFeatureType;
 }
 
 export type TrackedEntityTypeFeatureType = "none" | "point" | "polygon";

--- a/src/domain/entities/Geometry.ts
+++ b/src/domain/entities/Geometry.ts
@@ -1,0 +1,59 @@
+import { Maybe } from "../../types/utils";
+import { TrackedEntityType } from "./DataForm";
+
+export type Coordinates = { latitude: number; longitude: number };
+
+export type Geometry =
+    | { type: "none" }
+    | { type: "point"; coordinates: Coordinates }
+    | { type: "polygon"; coordinatesList: Coordinates[] };
+
+export function getGeometryAsString(geometry: Geometry): string {
+    switch (geometry.type) {
+        case "none":
+            return "";
+        case "point": {
+            const { longitude, latitude } = geometry.coordinates;
+            return `[${longitude}, ${latitude}]`;
+        }
+        case "polygon": {
+            const items = geometry.coordinatesList.map(
+                coordinates => `[${coordinates.longitude}, ${coordinates.latitude}]`
+            );
+            return `[${items.join(", ")}]`;
+        }
+    }
+}
+
+export function getGeometryFromString(trackedEntityType: Maybe<TrackedEntityType>, value: string): Geometry {
+    if (!trackedEntityType) {
+        console.error(`Expected tracked entity type on dataForm`);
+        return { type: "none" };
+    }
+    const cleanValue = value.trim().replace(/\s*/g, "");
+    if (!cleanValue) return { type: "none" };
+
+    switch (trackedEntityType.featureType) {
+        case "none":
+            return { type: "none" };
+        case "point":
+            return { type: "point", coordinates: getCoordinatesFromString(cleanValue) };
+        case "polygon": {
+            const match = cleanValue.match(/^\[(.+)\]/);
+            if (!match) throw new Error(`Invalid format for polygon: ${cleanValue}`);
+            // Perform split "[[lon1,lat1], [lat2,lon2]]"" -> ["[lon1,lat1]", "[lon1,lat1]"]
+            // Re-add the trailing "]" that got eaten by the split for each pair.
+            const items = (match[1] || "").split(/\]\s*,/).map(pairS => (!pairS.endsWith("]") ? pairS + "]" : pairS));
+            const coordinatesList = items.map(getCoordinatesFromString);
+            return { type: "polygon", coordinatesList };
+        }
+    }
+}
+
+function getCoordinatesFromString(s: string): Coordinates {
+    const match = s.match(/^\[([-+\d.]+),([-+\d.]+)\]$/);
+    if (!match) throw new Error(`Invalid format for a coordinate: ${s}`);
+
+    const [longitude = "", latitude = ""] = match.slice(1);
+    return { latitude: parseFloat(latitude), longitude: parseFloat(longitude) };
+}

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -168,6 +168,7 @@ export interface TeiRowDataSource {
     skipPopulate?: boolean;
     teiId: ColumnRef;
     orgUnit: ColumnRef;
+    geometry?: ColumnRef;
     enrollmentDate: ColumnRef;
     incidentDate: ColumnRef;
     attributes: Range;

--- a/src/domain/entities/TrackedEntityInstance.ts
+++ b/src/domain/entities/TrackedEntityInstance.ts
@@ -10,6 +10,31 @@ export interface TrackedEntityInstance {
     attributeValues: AttributeValue[];
     enrollment: Enrollment | undefined;
     relationships: Relationship[];
+    geometry: Geometry;
+}
+
+export type Coordinates = { latitude: number; longitude: number };
+
+export type Geometry =
+    | { type: "none" }
+    | { type: "point"; coordinates: Coordinates }
+    | { type: "polygon"; coordinatesList: Coordinates[] };
+
+export function getGeometryAsString(geometry: Geometry): string {
+    switch (geometry.type) {
+        case "none":
+            return "";
+        case "point": {
+            const { longitude, latitude } = geometry.coordinates;
+            return `[${longitude}, ${latitude}]`;
+        }
+        case "polygon": {
+            const items = geometry.coordinatesList.map(
+                coordinates => `[${coordinates.longitude}, ${coordinates.latitude}]`
+            );
+            return `[${items.join(", ")}]`;
+        }
+    }
 }
 
 export interface Enrollment {

--- a/src/domain/entities/TrackedEntityInstance.ts
+++ b/src/domain/entities/TrackedEntityInstance.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { Geometry } from "./Geometry";
 import { Id, Ref } from "./ReferenceObject";
 import { Relationship } from "./Relationship";
 
@@ -11,30 +12,6 @@ export interface TrackedEntityInstance {
     enrollment: Enrollment | undefined;
     relationships: Relationship[];
     geometry: Geometry;
-}
-
-export type Coordinates = { latitude: number; longitude: number };
-
-export type Geometry =
-    | { type: "none" }
-    | { type: "point"; coordinates: Coordinates }
-    | { type: "polygon"; coordinatesList: Coordinates[] };
-
-export function getGeometryAsString(geometry: Geometry): string {
-    switch (geometry.type) {
-        case "none":
-            return "";
-        case "point": {
-            const { longitude, latitude } = geometry.coordinates;
-            return `[${longitude}, ${latitude}]`;
-        }
-        case "polygon": {
-            const items = geometry.coordinatesList.map(
-                coordinates => `[${coordinates.longitude}, ${coordinates.latitude}]`
-            );
-            return `[${items.join(", ")}]`;
-        }
-    }
 }
 
 export interface Enrollment {

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -20,7 +20,7 @@ import {
     ValueRef,
 } from "../entities/Template";
 import { Theme, ThemeStyle } from "../entities/Theme";
-import { getRelationships } from "../entities/TrackedEntityInstance";
+import { getGeometryAsString, getRelationships } from "../entities/TrackedEntityInstance";
 import { ExcelRepository, ExcelValue } from "../repositories/ExcelRepository";
 import { BuilderMetadata, emptyBuilderMetadata, InstanceRepository } from "../repositories/InstanceRepository";
 
@@ -119,6 +119,15 @@ export class ExcelBuilder {
             const teiIdCell = await this.excelRepository.findRelativeCell(template.id, dataSource.teiId, cells[0]);
             if (teiIdCell && id) {
                 await this.excelRepository.writeCell(template.id, teiIdCell, id);
+            }
+
+            const geometryCell = await this.excelRepository.findRelativeCell(
+                template.id,
+                dataSource.geometry,
+                cells[0]
+            );
+            if (geometryCell) {
+                await this.excelRepository.writeCell(template.id, geometryCell, getGeometryAsString(tei.geometry));
             }
 
             const enrollmentDateCell = await this.excelRepository.findRelativeCell(

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -4,6 +4,7 @@ import { fromBase64 } from "../../utils/files";
 import { promiseMap } from "../../utils/promises";
 import { removeCharacters } from "../../utils/string";
 import { DataPackage } from "../entities/DataPackage";
+import { getGeometryAsString } from "../entities/Geometry";
 import { Relationship } from "../entities/Relationship";
 import {
     CellDataSource,
@@ -20,7 +21,7 @@ import {
     ValueRef,
 } from "../entities/Template";
 import { Theme, ThemeStyle } from "../entities/Theme";
-import { getGeometryAsString, getRelationships } from "../entities/TrackedEntityInstance";
+import { getRelationships } from "../entities/TrackedEntityInstance";
 import { ExcelRepository, ExcelValue } from "../repositories/ExcelRepository";
 import { BuilderMetadata, emptyBuilderMetadata, InstanceRepository } from "../repositories/InstanceRepository";
 

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -7,6 +7,7 @@ import { promiseMap } from "../../utils/promises";
 import { removeCharacters } from "../../utils/string";
 import { DataForm } from "../entities/DataForm";
 import { DataPackage, DataPackageData } from "../entities/DataPackage";
+import { getGeometryFromString } from "../entities/Geometry";
 import { Relationship } from "../entities/Relationship";
 import {
     CellDataSource,
@@ -23,7 +24,7 @@ import {
     TrackerRelationship,
     ValueRef,
 } from "../entities/Template";
-import { Coordinates, Geometry, TrackedEntityInstance } from "../entities/TrackedEntityInstance";
+import { TrackedEntityInstance } from "../entities/TrackedEntityInstance";
 import { ExcelRepository, ExcelValue, ReadCellOptions } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
 
@@ -374,7 +375,8 @@ export class ExcelReader {
             // Generate random one UID for TEI if empty.
             const teiId = (await this.getCellValue(template, dataSource.teiId, rowIdx)) || generateUid();
             const orgUnitId = await this.getFormulaValue(template, dataSource.orgUnit, rowIdx);
-            const geometry = parseGeometry(dataForm, await this.getCellValue(template, dataSource.geometry, rowIdx));
+            const geometryExcelValue = await this.getCellValue(template, dataSource.geometry, rowIdx);
+            const geometry = getGeometryFromString(dataForm.trackedEntityType, geometryExcelValue.toString());
             const enrollmentDate = parseDate(await this.getCellValue(template, dataSource.enrollmentDate, rowIdx));
             const incidentDate = parseDate(await this.getCellValue(template, dataSource.incidentDate, rowIdx));
 
@@ -479,35 +481,4 @@ export function parseDate(value: ExcelValue): ExcelValue {
     } else {
         return value;
     }
-}
-
-function parseGeometry(dataForm: DataForm, value: ExcelValue): Geometry {
-    const { trackedEntityType } = dataForm;
-    if (!trackedEntityType) {
-        console.error(`Expected tracked entity type on dataForm`);
-        return { type: "none" };
-    }
-    const strValue = value.toString().trim().replace(/\s*/g, "");
-    if (!strValue) return { type: "none" };
-
-    switch (trackedEntityType.featureType) {
-        case "none":
-            return { type: "none" };
-        case "point":
-            return { type: "point", coordinates: getCoordinatesFromString(strValue) };
-        case "polygon": {
-            const match = strValue.match(/^\[(.+)\]/);
-            if (!match) throw new Error(`Invalid format for polygon: ${strValue}`);
-            const coordinatesList = (match[1] || "").split(",").map(getCoordinatesFromString);
-            return { type: "polygon", coordinatesList };
-        }
-    }
-}
-
-function getCoordinatesFromString(s: string): Coordinates {
-    const match = s.match(/^\[([\d.]+),([\d.]+)\]$/);
-    if (!match) throw new Error(`Invalid format for a coordinate: ${s}`);
-
-    const [longitude = "", latitude = ""] = match.slice(1);
-    return { latitude: parseFloat(latitude), longitude: parseFloat(longitude) };
 }

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -169,7 +169,7 @@ async function getElement(api: D2Api, type: DataFormType, id: string) {
         "programType",
         "enrollmentDateLabel",
         "incidentDateLabel",
-        "trackedEntityType",
+        "trackedEntityType[id,featureType]",
         "captureCoordinates",
         "programTrackedEntityAttributes[trackedEntityAttribute[id,name,valueType,confidential,optionSet[id,name,options[id]]]],",
     ].join(",");

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -111,7 +111,7 @@ export function initializeMockServer() {
     mock.onGet("/programs", {
         params: {
             paging: false,
-            fields: "access,attributeValues[attribute[code],value],displayName,id,name,programStages[id,name,programStageDataElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id]],valueType]],repeatable],programTrackedEntityAttributes[trackedEntityAttribute[id,name]],programType,trackedEntityType[id]",
+            fields: "access,attributeValues[attribute[code],value],displayName,id,name,programStages[id,name,programStageDataElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id]],valueType]],repeatable],programTrackedEntityAttributes[trackedEntityAttribute[id,name]],programType,trackedEntityType[featureType,id]",
             filter: [],
         },
     }).reply(200, {
@@ -135,6 +135,7 @@ export function initializeMockServer() {
                 attributeValues: [],
                 programStages: [],
                 programTrackedEntityAttributes: [],
+                trackedEntityType: { id: "ZhmIeRK6IfG", featureType: "NONE" },
             },
         ],
     });

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,8 +1,8 @@
-import { D2Api } from "@eyeseetea/d2-api/2.30";
+import { D2Api } from "@eyeseetea/d2-api/2.33";
 import { getMockApiFromClass } from "@eyeseetea/d2-api";
 
-export * from "@eyeseetea/d2-api/2.30";
-export * from "@eyeseetea/d2-api/schemas/base";
+export * from "@eyeseetea/d2-api/2.33";
+export type { D2RelationshipConstraint } from "@eyeseetea/d2-api/schemas/base";
 
 export const D2ApiDefault = D2Api;
 export const getMockApi = getMockApiFromClass(D2Api);

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -20,9 +20,11 @@ export function isValueInUnionType<S, T extends S>(value: S, values: readonly T[
 }
 
 export function buildObject<Value>() {
-    return <T>(object: { [K in keyof T]: Value }) => object;
+    return <T extends {}>(object: { [K in keyof T]: Value }) => object;
 }
 
 export function isNotEmpty<T>(xs: T[] | undefined): xs is NonEmptyArray<T> {
     return xs ? xs.length > 0 : false;
 }
+
+export type KeysOfUnion<T> = T extends T ? keyof T : never;

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -14,7 +14,7 @@ import { getObjectVersion } from "./utils";
 
 export const dataSetId = "DATASET_GENERATED_v2";
 export const programId = "PROGRAM_GENERATED_v4";
-export const trackerProgramId = "TRACKER_PROGRAM_GENERATED_v2";
+export const trackerProgramId = "TRACKER_PROGRAM_GENERATED_v3";
 
 const teiSheetName = "TEI Instances";
 
@@ -369,10 +369,12 @@ export class SheetBuilder {
             )
         );
 
+        this.createFeatureTypeColumn({ program, sheet, itemRow, columnId: 3 });
+
         this.createColumn(
             sheet,
             itemRow,
-            3,
+            4,
             `${
                 program.enrollmentDateLabel
                     ? i18n.t(program.enrollmentDateLabel, { lng: this.builder.language })
@@ -383,7 +385,7 @@ export class SheetBuilder {
         this.createColumn(
             sheet,
             itemRow,
-            4,
+            5,
             (program.incidentDateLabel
                 ? i18n.t(program.incidentDateLabel, { lng: this.builder.language })
                 : i18n.t("Incident Date", { lng: this.builder.language })) + dateFormatInfo
@@ -398,7 +400,7 @@ export class SheetBuilder {
             if (tea.confidential) return;
             const validationId = tea.optionSet ? tea.optionSet.id : tea.valueType;
             const validation = this.validations.get(validationId);
-            this.createColumn(sheet, itemRow, 5 + idx, `_${tea.id}`, 1, validation);
+            this.createColumn(sheet, itemRow, 6 + idx, `_${tea.id}`, 1, validation);
             idx++;
         });
     }
@@ -1092,6 +1094,29 @@ export class SheetBuilder {
 
     private getTeiIdValidation() {
         return `='${teiSheetName}'!$A$${this.instancesSheetValuesRow}:$A$${maxTeiRows}`;
+    }
+
+    private createFeatureTypeColumn(options: { program: any; sheet: any; itemRow: number; columnId: number }) {
+        const { program, sheet, itemRow, columnId } = options;
+        const header = this.getFeatureTypeHeader(program);
+        const defaultHeader = i18n.t("No geometry", { lng: this.builder.language });
+
+        this.createColumn(sheet, itemRow, 3, header || defaultHeader);
+        if (!header) sheet.column(columnId).hide();
+    }
+
+    private getFeatureTypeHeader(program: any): string | undefined {
+        const { featureType } = program.trackedEntityType;
+        const opts = { lng: this.builder.language };
+
+        switch (featureType) {
+            case "POINT":
+                return [i18n.t("Point in map", opts), "([LON, LAT])"].join("\n");
+            case "POLYGON":
+                return [i18n.t("Polygon in map", opts), "([[LON1, LAT1], [LON2, LAT2], ...])"].join("\n");
+            default:
+                return undefined;
+        }
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.10.0.tgz#6849e4023d699d0db8c040814e77bafdc1681e98"
-  integrity sha512-WHEDhEnjGK5U0kCctB/CjzpEAZyDiwnMyuusPaOMNxJWktOZMjik8aOYbmWRBg2R2z6jHPqezpRwJST+qx5DhQ==
+"@eyeseetea/d2-api@1.10.2-beta.2":
+  version "1.10.2-beta.2"
+  resolved "https://registry.npmjs.org/@eyeseetea/d2-api/-/d2-api-1.10.2-beta.2.tgz#2a1c160276184fad52d3eeae38a680651f0ba843"
+  integrity sha512-UYVW46grASx38kGv+AM2oeUcz+PUhqi+lK3KHjinYuMUGPjfpIFKwjractbub4uZXejyEVzbpmvl14KJstL2pw==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/1vqyygd
* **d2-api**: Requires https://github.com/EyeSeeTea/d2-api/pull/121 -> 1.10.2-beta.2

### :memo: Implementation

- Added new template v3 for tracker programs.
- Added column `geometry` in position C (hidden if no necessary -> featureType = NONE)
- Added entities `Coordinates` and `Geometry`
- Manual parsing of point/polygon (codec should not be used in an entity, no clear repo where to add it; JSON.parse still would need manual type checks).

NOTES:

- An error on the geometry field is an error that stops the process. Do we want instead to skip the cell and continue?
- The type of Polygon in D2 is `Array<Array<[Long, Lat]>>`. That, in fact, allows not one, but multiple polygons. However, the Tracker Capture UI (register & edit profile) only allows creating a single polygon. So, for simplicity, in our domain we have `Array<Long, Lat>` and we only get the first polygon in the API object.  This removes a nesting level which would be confusing for an already complicated column.

### :fire: Notes for the reviewer

3 scenarios to test, depending on `trackedEntityType.featureType`: none, point, polygon. Test rows with and without value. Invalid encoded values should raise a controlled error (snackbar)

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/151781178-a4b4eafe-b131-4753-a52e-dac32119a831.png)
