### PR TITLE
Fix/translations

### DIFF
--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -4,6 +4,7 @@ import _ from "lodash";
 import { Moment } from "moment";
 import { UseCase } from "../../CompositionRoot";
 import { getRelationshipMetadata, RelationshipOrgUnitFilter } from "../../data/Dhis2RelationshipTypes";
+import i18n from "../../locales";
 import { D2Api } from "../../types/d2-api";
 import { promiseMap } from "../../utils/promises";
 import Settings from "../../webapp/logic/settings";
@@ -60,6 +61,7 @@ export class DownloadTemplateUseCase implements UseCase {
             relationshipsOuFilter,
         }: DownloadTemplateProps
     ): Promise<void> {
+        i18n.setDefaultNamespace("bulk-load");
         const { id: templateId } = getTemplateId(type, id);
         const template = this.templateRepository.getTemplate(templateId);
         const theme = themeId ? await this.templateRepository.getTheme(themeId) : undefined;

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -330,7 +330,7 @@ export const compareDataPackages = (
 
 const formatDhis2Value = (item: DataPackageDataValue, dataForm: DataForm): DataPackageDataValue | undefined => {
     const dataElement = dataForm.dataElements.find(({ id }) => item.dataElement === id);
-    const booleanValue = String(item.value) === "true" || item.value === "Yes";
+    const booleanValue = String(item.optionId) === "true" || item.optionId === "true";
 
     if (dataElement?.valueType === "BOOLEAN") {
         return { ...item, value: booleanValue };

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -11,6 +11,7 @@ declare module "@dhis2/d2-i18n" {
     export function t(value: string): string;
     export function t(value: string, options?: { [key: string]: any }): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }
 
 declare module "nano-memoize" {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes # Translation problem with bulk load template and upload
* **d2-api**: Requires #
* **d2-ui-components**: Requires #

### :memo: Implementation


There was a problem with the translations of the boolean and true_false data types.
arnau quote:
i18n error was hard to track: i18n.options.defaultNS should be "bulk-load", but it was default. I tracked it down to @dhis2/ui-widgets ➝ HeaderBar, which was changing the value to default. Workaround, run i18n.setDefaultNamespace("bulk-load");` somewhere after the header has been loaded.


- Fixed by resetting the namespace to bulk-load in the download use case.


After resolving it there was a minor issue where the translated values ​​were not being imported correctly.

-Fixed changing the boolean value from the translated value to the value code.

### :fire: Notes for the reviewer
download and import same program (with boolean (yes/no) and true only values) in english and in portuguese, and check that the data is imported and the don't have data lost.
### :art: Screenshots

### :bookmark_tabs: Others
