### PR TITLE
Tests with 2.37 / 2.38

### DIFF
--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -253,7 +253,9 @@ async function getConstraintForTypeTei(
         fields: "trackedEntityInstance",
     } as const;
 
-    const results = await promiseMap(_.chunk(query.ou, 250), async ouChunk => {
+    const orgUnitsChunks = query.ou ? _.chunk(query.ou, 250) : [[]];
+
+    const results = await promiseMap(orgUnitsChunks, async ouChunk => {
         const filterQuery =
             query.ouMode === "SELECTED" || query.ouMode === "CHILDREN" || query.ouMode === "DESCENDANTS"
                 ? { ...query, ou: ouChunk }

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -467,7 +467,8 @@ function getFormulaWithValidation(workbook: XLSX.Workbook, sheet: SheetWithValid
 }
 
 function _getFormulaWithValidation(workbook: XLSX.Workbook, sheet: SheetWithValidations, cell: XLSX.Cell) {
-    const defaultValue = cell.formula();
+    // Formulas some times return the = prefix, which the called does not expect. Force the removal.
+    const defaultValue = cell.formula()?.replace(/^=/, "");
     const value = getValue(cell);
     if (defaultValue || !value) return defaultValue;
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/34bkxjk

### :fire: Tested

- Versions tested: 2.37.7.1 and 2.38.1 (using d2-docker@development, needs Java 11)

- Import/export for:
  - data sets
  - event programs
  - tracked programs (with a TEI/TEI relationships)

### :memo: Implementation

- [2.37] We were getting a Conflict 409 error on `/api/trackedEntityInstances` -> "Either Program or Tracked entity type should be specified". Solution: get all trackedEntityTypes and perform a request for each type.
- Force formulas string removal of the formula prefix (=): Not related to the DHIS version, but I was getting formulas like this `=_SOMEID`, which is wrong, `=` should be removed from the formula. That happened when trying to import dataSets with no modification of the spreadsheet so I am a bit confused as to why we had not encountered that before.
- Fix getConstraintForTypeTei when no org unit to filter by: fixes a bug on the paginated get of `trackedEntityInstances`.

NOTES:

- [Not related to 2.37/2.38, it happens on 2.36] While testing, I detected a problem while importing tracked program events. Scenario: I have two events (different IDs), same program stage, BUT different TEIs. On post, I get this error:  `"description": "ProgramStage Rt4kDlLqdBf is not repeatable. The current payload contains duplicate event"`. And only the first event is created. But this makes no sense to me, they are different TEIs. Wehn I post the same payload again, no error is returned and the second event is created without problems. No JIRA issue was found (the inverse case: https://jira.dhis2.org/browse/DHIS2-10021). So the workaround for this problem is to post the Excel twice. JIRA issue created: https://jira.dhis2.org/browse/DHIS2-13518

