### PR TITLE
Grant all permissions for everyone on initial migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bulk-load",
     "description": "Bulk importing made easy",
-    "version": "3.19.0",
+    "version": "3.19.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/data/migrations/tasks/01.settings-permissions.ts
+++ b/src/data/migrations/tasks/01.settings-permissions.ts
@@ -75,9 +75,9 @@ export async function migrate(storage: AppStorage, _debug: Debug, params: Migrat
         permissionsForGeneration: await mapSharingSettings(api, settings.permissionsForGeneration),
         permissionsForSettings: await mapSharingSettings(api, settings.permissionsForSettings),
         permissionsForImport: await mapSharingSettings(api, settings.permissionsForImport),
-        allPermissionsForGeneration: settings.permissionsForGeneration?.includes("ALL"),
-        allPermissionsForSettings: settings.permissionsForSettings?.includes("ALL"),
-        allPermissionsForImport: settings.permissionsForImport?.includes("ALL"),
+        allPermissionsForGeneration: true,
+        allPermissionsForSettings: true,
+        allPermissionsForImport: true,
     };
 
     await storage.save<Partial<NewAppSettings>>("BULK_LOAD_SETTINGS", newSettings);


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/3kqq7th

### :memo: Implementation

- Change `migrations/tasks/01.settings-permissions.ts` so the setting for "all" access is enabled by default (not it was only if the user was a superadmin). 
- On already installed apps, it has no effect.