### PR TITLE
Feature/show sections as tabs

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-04-29T09:28:31.324Z\n"
-"PO-Revision-Date: 2022-04-29T09:28:31.324Z\n"
+"POT-Creation-Date: 2022-10-21T11:58:05.943Z\n"
+"PO-Revision-Date: 2022-10-21T11:58:05.943Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -687,6 +687,9 @@ msgid "Advanced template properties"
 msgstr ""
 
 msgid "Language"
+msgstr ""
+
+msgid "Split data entry tabs by section"
 msgstr ""
 
 msgid "Theme"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-04-29T09:28:31.324Z\n"
+"POT-Creation-Date: 2022-10-21T11:58:05.943Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -715,6 +715,9 @@ msgstr "Propiedades avanzadas de la plantilla"
 
 msgid "Language"
 msgstr "Idioma"
+
+msgid "Split data entry tabs by section"
+msgstr ""
 
 msgid "Theme"
 msgstr "Tema"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2022-04-29T09:28:31.324Z\n"
+"POT-Creation-Date: 2022-10-21T11:58:05.943Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -737,6 +737,9 @@ msgstr "Propriétés avancées du modèle"
 
 msgid "Language"
 msgstr "Langue"
+
+msgid "Split data entry tabs by section"
+msgstr ""
 
 msgid "Theme"
 msgstr "Thème"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-04-29T09:28:31.324Z\n"
+"POT-Creation-Date: 2022-10-21T11:58:05.943Z\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -770,6 +770,9 @@ msgstr "Propriedades avançadas da planilha"
 
 msgid "Language"
 msgstr "Língua"
+
+msgid "Split data entry tabs by section"
+msgstr ""
 
 msgid "Theme"
 msgstr "Tema"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2022-04-29T09:28:31.324Z\n"
+"POT-Creation-Date: 2022-10-21T11:58:05.943Z\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgid "Data values - Create/update"
 msgstr "Значения данных - создание/обновление"
@@ -772,6 +772,9 @@ msgstr "Расширенные свойства шаблона"
 
 msgid "Language"
 msgstr "Язык"
+
+msgid "Split data entry tabs by section"
+msgstr ""
 
 msgid "Theme"
 msgstr "Тема"

--- a/src/data/templates/generated-data-set/DataSetGenerated.02.ts
+++ b/src/data/templates/generated-data-set/DataSetGenerated.02.ts
@@ -4,7 +4,7 @@ export class DataSetGenerated02 implements GeneratedTemplate {
     public readonly type = "generated";
     public readonly id = "DATASET_GENERATED_v2";
     public readonly name = "Auto-generated dataSet template";
-    public readonly dataFormId = { type: "cell" as const, sheet: "Data Entry", ref: "A4" };
+    public readonly dataFormId = { type: "cell" as const, sheet: 0, ref: "A4" };
     public readonly dataFormType = { type: "value" as const, id: "dataSets" as const };
 
     public readonly rowOffset = 3;

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -13,6 +13,7 @@ import {
     DataSourceValue,
     DownloadCustomizationOptions,
     RowDataSource,
+    setDataEntrySheet,
     setSheet,
     SheetRef,
     TeiRowDataSource,
@@ -85,6 +86,8 @@ export class ExcelBuilder {
                     .map(sheet => (sheet.name.match(dataSource.sheetsMatch) ? setSheet(dataSource, sheet.name) : null))
                     .compact()
                     .value();
+            } else if (dataSource.type === "row") {
+                return setDataEntrySheet(dataSource, sheets);
             } else {
                 return [dataSource];
             }

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -435,7 +435,7 @@ export class ExcelReader {
             });
 
             const definedNames = await this.excelRepository.listDefinedNames(template.id);
-            if (typeof formula === "string" && definedNames.includes(formula)) {
+            if (typeof formula === "string" && definedNames.includes(formula.replace(/^=/, ""))) {
                 return removeCharacters(formula);
             }
 

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -17,6 +17,7 @@ import {
     DataSourceValue,
     GenericSheetRef,
     RowDataSource,
+    setDataEntrySheet,
     setSheet,
     SheetRef,
     TeiRowDataSource,
@@ -465,6 +466,8 @@ export class ExcelReader {
                     .map(sheet => (sheet.name.match(dataSource.sheetsMatch) ? setSheet(dataSource, sheet.name) : null))
                     .compact()
                     .value();
+            } else if (dataSource.type === "row") {
+                return setDataEntrySheet(dataSource, sheets);
             } else {
                 return [dataSource];
             }

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -35,6 +35,7 @@ export interface DownloadTemplateProps {
     relationshipsOuFilter?: RelationshipOrgUnitFilter;
     templateId?: string;
     templateType?: TemplateType;
+    splitDataEntryTabsBySection: boolean;
 }
 
 export class DownloadTemplateUseCase implements UseCase {
@@ -64,6 +65,7 @@ export class DownloadTemplateUseCase implements UseCase {
             relationshipsOuFilter,
             templateId: customTemplateId,
             templateType,
+            splitDataEntryTabsBySection,
         }: DownloadTemplateProps
     ): Promise<void> {
         i18n.setDefaultNamespace("bulk-load");
@@ -103,6 +105,7 @@ export class DownloadTemplateUseCase implements UseCase {
                 template,
                 settings,
                 downloadRelationships,
+                splitDataEntryTabsBySection,
             });
             const workbook = await sheetBuilder.generate();
 

--- a/src/webapp/components/settings/TemplateListTable.tsx
+++ b/src/webapp/components/settings/TemplateListTable.tsx
@@ -143,6 +143,7 @@ export default function TemplateListTable(props: TemplateListTableProps) {
                     settings,
                     populate: false,
                     downloadRelationships: false,
+                    splitDataEntryTabsBySection: false,
                 });
             } else {
                 snackbar.error(i18n.t("Cannot download spreadsheet for template"));

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -59,7 +59,14 @@ export const TemplateSelector = ({ settings, themes, onChange, customTemplates }
         filterTEIEnrollmentDate: false,
         language: "en",
         settings,
+        splitDataEntryTabsBySection: false,
     });
+
+    const selectedId = state.id;
+    const isDataSet = React.useMemo(() => {
+        const dataSetIds = dataSource?.dataSets?.map(ds => ds.id);
+        return selectedId && dataSetIds && dataSetIds.includes(selectedId);
+    }, [selectedId, dataSource]);
 
     const models = useMemo(() => {
         return _.compact([
@@ -217,6 +224,10 @@ export const TemplateSelector = ({ settings, themes, onChange, customTemplates }
         setState(state => ({ ...state, downloadRelationships }));
     };
 
+    const toggleSplitDataEntryTabsBySection = () => {
+        setState(state => ({ ...state, splitDataEntryTabsBySection: !state.splitDataEntryTabsBySection }));
+    };
+
     const onFilterTEIEnrollmentDateChange = (_event: React.ChangeEvent, filterTEIEnrollmentDate: boolean) => {
         setState(state => ({ ...state, filterTEIEnrollmentDate }));
     };
@@ -362,6 +373,20 @@ export const TemplateSelector = ({ settings, themes, onChange, customTemplates }
                     </div>
                 </div>
             )}
+
+            {isDataSet && (
+                <FormControlLabel
+                    className={classes.checkbox}
+                    control={
+                        <Checkbox
+                            checked={state.splitDataEntryTabsBySection}
+                            onChange={toggleSplitDataEntryTabsBySection}
+                        />
+                    }
+                    label={i18n.t("Split data entry tabs by section")}
+                />
+            )}
+
             {themeOptions.length > 0 && state.templateType !== "custom" && (
                 <div className={classes.row}>
                     <div className={classes.select}>

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -60,6 +60,7 @@ export class SheetBuilder {
     private relationshipsSheets: any;
     private dataEntrySheet: any;
     private legendSheet: any;
+    private dataSetSheet: any;
     private validationSheet: any;
     private metadataSheet: any;
 
@@ -73,6 +74,7 @@ export class SheetBuilder {
     public generate() {
         const { builder } = this;
         const { element } = builder;
+        const { rawMetadata } = this.builder;
 
         if (isTrackerProgram(element)) {
             const { elementMetadata: metadata } = builder;
@@ -100,6 +102,12 @@ export class SheetBuilder {
         } else {
             this.dataEntrySheet = this.workbook.addWorksheet("Data Entry");
         }
+
+        _.sortBy(rawMetadata["dataElements"], ["name"]).forEach(item => {
+            const { name } = this.translate(item);
+            this.dataSetSheet = this.workbook.addWorksheet(name, protectedSheet);
+            this.fillDataSetSheet();
+        });
 
         this.legendSheet = this.workbook.addWorksheet("Legend", protectedSheet);
         this.validationSheet = this.workbook.addWorksheet("Validation", protectedSheet);
@@ -403,6 +411,24 @@ export class SheetBuilder {
             const validation = this.validations.get(validationId);
             this.createColumn(sheet, itemRow, 6 + idx, `_${tea.id}`, 1, validation);
             idx++;
+        });
+    }
+
+    private fillDataSetSheet() {
+        const { rawMetadata } = this.builder;
+        const dataSetSheet = this.dataSetSheet;
+
+        // Freeze and format column titles
+        dataSetSheet.row(2).freeze();
+        dataSetSheet.column(1).setWidth(50);
+
+        _.sortBy(rawMetadata["dataElements"], ["name"]).forEach(item => {
+            const { name } = this.translate(item);
+
+            dataSetSheet
+                .cell(1, 1, 2, 1, true)
+                .string(name ?? "")
+                .style(baseStyle);
         });
     }
 

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -73,8 +73,7 @@ export class SheetBuilder {
 
     public generate() {
         const { builder } = this;
-        const { element } = builder;
-        const { rawMetadata } = this.builder;
+        const { element, rawMetadata } = builder;
 
         if (isTrackerProgram(element)) {
             const { elementMetadata: metadata } = builder;
@@ -103,11 +102,14 @@ export class SheetBuilder {
             this.dataEntrySheet = this.workbook.addWorksheet("Data Entry");
         }
 
-        _.sortBy(rawMetadata["dataElements"], ["name"]).forEach(item => {
-            const { name } = this.translate(item);
-            this.dataSetSheet = this.workbook.addWorksheet(name, protectedSheet);
-            this.fillDataSetSheet();
-        });
+        if (element.formType === "SECTION") {
+            _.sortBy(rawMetadata["sections"], ["name", "id"]).forEach(item => {
+                const { name } = this.translate(item);
+
+                this.dataSetSheet = this.workbook.addWorksheet(name, protectedSheet);
+                this.fillSectionSheet(item.id);
+            });
+        }
 
         this.legendSheet = this.workbook.addWorksheet("Legend", protectedSheet);
         this.validationSheet = this.workbook.addWorksheet("Validation", protectedSheet);
@@ -414,7 +416,7 @@ export class SheetBuilder {
         });
     }
 
-    private fillDataSetSheet() {
+    private fillSectionSheet(id: any) {
         const { rawMetadata } = this.builder;
         const dataSetSheet = this.dataSetSheet;
 
@@ -422,13 +424,11 @@ export class SheetBuilder {
         dataSetSheet.row(2).freeze();
         dataSetSheet.column(1).setWidth(50);
 
-        _.sortBy(rawMetadata["dataElements"], ["name"]).forEach(item => {
-            const { name } = this.translate(item);
-
-            dataSetSheet
-                .cell(1, 1, 2, 1, true)
-                .string(name ?? "")
-                .style(baseStyle);
+        _.find(rawMetadata.sections, item => {
+            if (item.id === id) {
+                dataSetSheet.cell(1, 1, 2, 1, true).string(item.name ?? "");
+                return true;
+            }
         });
     }
 

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -441,6 +441,7 @@ export class SheetBuilder {
 
         // Add column titles
         let columnId = 1;
+        let groupId = 0;
 
         this.createColumn(
             dataSetSheet,
@@ -475,17 +476,31 @@ export class SheetBuilder {
             .formula(`_${element.id}`)
             .style({ ...baseStyle, font: { size: 16, bold: true } });
 
-        let rowId = 6;
-        _.find(rawMetadata.sections, item => {
-            if (item.id === id) {
-                this.createColumn(dataSetSheet, itemRow, columnId++, item.name);
-                _.forEach(item.dataElements, dataElement => {
-                    dataSetSheet
-                        .cell(rowId, 4)
-                        .string(rawMetadata.dataElements.find((i: { id: any }) => i.id === dataElement.id).name ?? "");
-                    rowId++;
+        _.find(rawMetadata.sections, section => {
+            if (section.id === id) {
+                const firstColumnId = columnId;
+
+                _.forEach(section.dataElements, dataElement => {
+                    this.createColumn(
+                        dataSetSheet,
+                        itemRow,
+                        columnId,
+                        `_${dataElement.id}`,
+                        groupId,
+                    );
+
+                    columnId++;
                 });
-                return true;
+
+                const noColumnAdded = columnId === firstColumnId;
+                if (noColumnAdded) return;
+
+                dataSetSheet
+                    .cell(sectionRow, firstColumnId, sectionRow, columnId - 1, true)
+                    .formula(`_${section.id}`)
+                    .style(this.groupStyle(groupId));
+
+                groupId++;
             }
         });
     }

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -74,6 +74,7 @@ export class SheetBuilder {
     public generate() {
         const { builder } = this;
         const { element, rawMetadata } = builder;
+        const useDataSetSections = element.formType === "SECTION" || !_(element.sections).isEmpty();
 
         if (isTrackerProgram(element)) {
             const { elementMetadata: metadata } = builder;
@@ -98,15 +99,15 @@ export class SheetBuilder {
                     }
                 );
             }
-        } else if (element.formType !== "SECTION") {
+        } else if (!useDataSetSections) {
             this.dataEntrySheet = this.workbook.addWorksheet("Data Entry");
         }
 
-        if (element.formType === "SECTION" && element.type === "dataSets") {
+        if (useDataSetSections) {
             _.sortBy(rawMetadata["sections"], ["name", "id"]).forEach(item => {
                 const { name } = this.translate(item);
 
-                this.dataSetSheet = this.workbook.addWorksheet(`Data Entry- ${name}`, protectedSheet);
+                this.dataSetSheet = this.workbook.addWorksheet(`Data Entry- ${name}`);
                 this.fillSectionSheet(item.id);
             });
         }
@@ -123,7 +124,7 @@ export class SheetBuilder {
             this.fillInstancesSheet();
             this.fillProgramStageSheets();
             this.fillRelationshipSheets();
-        } else if (element.formType !== "SECTION") {
+        } else if (!useDataSetSections) {
             this.fillDataEntrySheet();
         }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/34057te

### :memo: Implementation

- Both generation and import dynamically convert a data source of type `row` (the ones used for data sets data entries) from some existing definition (for example: `sheet = "Data Entry"`) to multiple data sources, matching names from the sheet tabs with the same prefix. 
- This approach only works when all sheet names are the same (which is the typical use case). 
- This approach allows no change on templates and it also works on custom forms.
- Automatic form: Data Set ID cell is get from the sheet with index 0 (the first sheet) instead of hardcoded "Data Entry". So it works for old and new scenarios.

### :fire: Notes for the reviewer

https://dev.eyeseetea.com/who-dev-236/dhis-web-maintenance/index.html#/edit/dataSetSection/dataSet
/FdZVd9tIFiA 
(ignacio.foche / ...)
Data set: `0. Test Split Sections` with 2 sections, assigned to organization unit `Global`.

- Test Generation UI flag "Split data entry tabs by section" (on and off). This flag is only visible for data sets.
- It should work for automatic and custom templates.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/197193595-51b5f6ee-c10d-4a62-bfeb-066e91695145.png)

![image](https://user-images.githubusercontent.com/24643/197193505-39293638-23de-484b-9349-9d8f01d71f1f.png)