### PR TITLE
[Fix] Fix generation UI logic for custom templates

### DIFF
--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -74,7 +74,7 @@ export const TemplateSelector = ({
         splitDataEntryTabsBySection: false,
     });
 
-    const selectedId = state.id;
+    const selectedId = state.templateId || state.id;
     const isDataSet = React.useMemo(() => {
         const dataSetIds = dataSource?.dataSets?.map(ds => ds.id);
         return selectedId && dataSetIds && dataSetIds.includes(selectedId);

--- a/src/webapp/pages/download-template/DownloadTemplatePage.tsx
+++ b/src/webapp/pages/download-template/DownloadTemplatePage.tsx
@@ -17,10 +17,10 @@ export default function DownloadTemplatePage({ settings, themes, customTemplates
     const { api, compositionRoot } = useAppContext();
 
     const [template, setTemplate] = useState<TemplateSelectorState | null>(null);
-    const [availableModels, setAvailableModels] = useState<DataModelProps[]>([]);
+    const [_availableModels, setAvailableModels] = useState<DataModelProps[]>([]);
 
     const handleTemplateDownloadClick = async () => {
-        if (!template || availableModels.filter(availableModel => template?.id === availableModel.value).length === 0) {
+        if (!template) {
             snackbar.info(i18n.t("You need to select at least one element to export"));
             return;
         }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/860qhqq7e

### :memo: Implementation

- Permissions for custom template use the code, that's correct, the ID must be used for autogenerated forms. 
- The problem was with the matching templateCode/selectedId in the view, fixed. 

### :fire: Notes for the reviewer

Validated by @idelcano  in https://portal-uat.who.int/dhis2