### PR TITLE
Add support for images

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "excel4node": "1.7.2",
         "file-saver": "2.0.5",
         "jquery": "3.6.0",
+        "jszip": "3.10.1",
         "lodash": "4.17.21",
         "lodash.product": "18.9.19",
         "md5": "2.3.0",

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -42,6 +42,7 @@ import { WriteSettingsUseCase } from "./domain/usecases/WriteSettingsUseCase";
 import { D2Api } from "./types/d2-api";
 import { GetFilteredThemesUseCase } from "./domain/usecases/GetFilteredThemesUseCase";
 import { FileD2Repository } from "./data/FileD2Repository";
+import { ImportSourceZipRepository } from "./data/ImportSourceZipRepository";
 
 export interface CompositionRootOptions {
     appConfig: JsonConfig;
@@ -61,6 +62,7 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: Composi
     const migrations: MigrationsRepository = new MigrationsAppRepository(storage, dhisInstance);
     const usersRepository = new D2UsersRepository(dhisInstance);
     const fileRepository = new FileD2Repository(dhisInstance);
+    const importSourceRepository = new ImportSourceZipRepository();
 
     return {
         orgUnits: getExecute({
@@ -74,7 +76,13 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: Composi
         templates: getExecute({
             analyze: new AnalyzeTemplateUseCase(instance, templateManager, excelReader),
             download: new DownloadTemplateUseCase(instance, templateManager, excelReader),
-            import: new ImportTemplateUseCase(instance, templateManager, excelReader, fileRepository),
+            import: new ImportTemplateUseCase(
+                instance,
+                templateManager,
+                excelReader,
+                fileRepository,
+                importSourceRepository
+            ),
             list: new ListDataFormsUseCase(instance),
             getDataFormsForGeneration: new GetDataFormsForGenerationUseCase(instance),
             get: new GetDataFormsUseCase(instance),

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -41,6 +41,7 @@ import { SearchUsersUseCase } from "./domain/usecases/SearchUsersUseCase";
 import { WriteSettingsUseCase } from "./domain/usecases/WriteSettingsUseCase";
 import { D2Api } from "./types/d2-api";
 import { GetFilteredThemesUseCase } from "./domain/usecases/GetFilteredThemesUseCase";
+import { FileD2Repository } from "./data/FileD2Repository";
 
 export interface CompositionRootOptions {
     appConfig: JsonConfig;
@@ -59,6 +60,7 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: Composi
     const excelReader: ExcelRepository = new ExcelPopulateRepository();
     const migrations: MigrationsRepository = new MigrationsAppRepository(storage, dhisInstance);
     const usersRepository = new D2UsersRepository(dhisInstance);
+    const fileRepository = new FileD2Repository(dhisInstance);
 
     return {
         orgUnits: getExecute({
@@ -72,7 +74,7 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: Composi
         templates: getExecute({
             analyze: new AnalyzeTemplateUseCase(instance, templateManager, excelReader),
             download: new DownloadTemplateUseCase(instance, templateManager, excelReader),
-            import: new ImportTemplateUseCase(instance, templateManager, excelReader),
+            import: new ImportTemplateUseCase(instance, templateManager, excelReader, fileRepository),
             list: new ListDataFormsUseCase(instance),
             getDataFormsForGeneration: new GetDataFormsForGenerationUseCase(instance),
             get: new GetDataFormsUseCase(instance),

--- a/src/data/FileD2Repository.ts
+++ b/src/data/FileD2Repository.ts
@@ -1,0 +1,56 @@
+import { D2Api } from "@eyeseetea/d2-api/2.33";
+import _ from "lodash";
+import { DhisInstance } from "../domain/entities/DhisInstance";
+import { FileResource } from "../domain/entities/FileResource";
+import { FileRepository } from "../domain/repositories/FileRepository";
+import { D2ApiDefault } from "../types/d2-api";
+import { promiseMap } from "../utils/promises";
+
+type FileResponse = {
+    response?: {
+        fileResource?: {
+            id?: string;
+        };
+    };
+};
+
+export class FileD2Repository implements FileRepository {
+    private api: D2Api;
+
+    constructor(localInstance: DhisInstance) {
+        this.api = new D2ApiDefault({ baseUrl: localInstance.url });
+    }
+
+    async uploadAll(files: FileResource[]): Promise<FileResource[]> {
+        if (files.length === 0) return files;
+
+        const filesWithIds = await promiseMap(_.chunk(files, 10), async chunkFiles => {
+            const fileUploaded = await promiseMap(chunkFiles, async file => {
+                const formData = new FormData();
+                formData.append("file", file.data, file.name);
+                formData.append("domain", "DATA_VALUE");
+
+                const response = await this.api
+                    .request<FileResponse>({
+                        url: "/fileResources",
+                        method: "post",
+                        requestBodyType: "raw",
+                        data: formData,
+                    })
+                    .response();
+
+                const fileResourceId = response.data.response?.fileResource;
+
+                if (!fileResourceId?.id) {
+                    throw Error("Unable to save file");
+                }
+
+                return { ...file, id: fileResourceId.id };
+            });
+
+            return fileUploaded;
+        });
+
+        return _.flatten(filesWithIds);
+    }
+}

--- a/src/data/FileD2Repository.ts
+++ b/src/data/FileD2Repository.ts
@@ -1,5 +1,4 @@
 import { D2Api } from "@eyeseetea/d2-api/2.33";
-import _ from "lodash";
 import { DhisInstance } from "../domain/entities/DhisInstance";
 import { FileResource } from "../domain/entities/FileResource";
 import { FileRepository } from "../domain/repositories/FileRepository";
@@ -24,33 +23,29 @@ export class FileD2Repository implements FileRepository {
     async uploadAll(files: FileResource[]): Promise<FileResource[]> {
         if (files.length === 0) return files;
 
-        const filesWithIds = await promiseMap(_.chunk(files, 10), async chunkFiles => {
-            const fileUploaded = await promiseMap(chunkFiles, async file => {
-                const formData = new FormData();
-                formData.append("file", file.data, file.name);
-                formData.append("domain", "DATA_VALUE");
+        const filesWithIds = await promiseMap(files, async file => {
+            const formData = new FormData();
+            formData.append("file", file.data, file.name);
+            formData.append("domain", "DATA_VALUE");
 
-                const response = await this.api
-                    .request<FileResponse>({
-                        url: "/fileResources",
-                        method: "post",
-                        requestBodyType: "raw",
-                        data: formData,
-                    })
-                    .response();
+            const response = await this.api
+                .request<FileResponse>({
+                    url: "/fileResources",
+                    method: "post",
+                    requestBodyType: "raw",
+                    data: formData,
+                })
+                .response();
 
-                const fileResourceId = response.data.response?.fileResource;
+            const fileResourceId = response.data.response?.fileResource;
 
-                if (!fileResourceId?.id) {
-                    throw Error("Unable to save file");
-                }
+            if (!fileResourceId?.id) {
+                throw Error("Unable to save file");
+            }
 
-                return { ...file, id: fileResourceId.id };
-            });
-
-            return fileUploaded;
+            return { ...file, id: fileResourceId.id };
         });
 
-        return _.flatten(filesWithIds);
+        return filesWithIds;
     }
 }

--- a/src/data/ImportSourceZipRepository.ts
+++ b/src/data/ImportSourceZipRepository.ts
@@ -1,0 +1,15 @@
+import { ImportSource } from "../domain/entities/FileResource";
+import { ImportSourceRepository } from "../domain/repositories/ImportSourceRepository";
+import { extractImagesFromZip, getExcelOrThrow } from "./../utils/files";
+
+export class ImportSourceZipRepository implements ImportSourceRepository {
+    async import(file: File): Promise<ImportSource> {
+        const excelFile = await getExcelOrThrow(file);
+        const images = await extractImagesFromZip(file);
+
+        return {
+            images,
+            spreadSheet: excelFile,
+        };
+    }
+}

--- a/src/domain/entities/FileResource.ts
+++ b/src/domain/entities/FileResource.ts
@@ -1,0 +1,7 @@
+import { Id } from "./ReferenceObject";
+
+export type FileResource = {
+    id: Id;
+    name: string;
+    data: Blob;
+};

--- a/src/domain/entities/FileResource.ts
+++ b/src/domain/entities/FileResource.ts
@@ -5,3 +5,5 @@ export type FileResource = {
     name: string;
     data: Blob;
 };
+
+export type ImportSource = { spreadSheet: Blob; images: FileResource[] };

--- a/src/domain/repositories/FileRepository.ts
+++ b/src/domain/repositories/FileRepository.ts
@@ -1,0 +1,5 @@
+import { FileResource } from "../entities/FileResource";
+
+export interface FileRepository {
+    uploadAll(files: FileResource[]): Promise<FileResource[]>;
+}

--- a/src/domain/repositories/ImportSourceRepository.ts
+++ b/src/domain/repositories/ImportSourceRepository.ts
@@ -1,0 +1,5 @@
+import { ImportSource } from "../entities/FileResource";
+
+export interface ImportSourceRepository {
+    import(file: File): Promise<ImportSource>;
+}

--- a/src/domain/usecases/AnalyzeTemplateUseCase.ts
+++ b/src/domain/usecases/AnalyzeTemplateUseCase.ts
@@ -16,10 +16,7 @@ export class AnalyzeTemplateUseCase implements UseCase {
     public async execute(file: File) {
         const excelFile = await getExcelOrThrow(file);
 
-        const templateId = await this.excelRepository.loadTemplate({
-            type: "file",
-            file: excelFile,
-        });
+        const templateId = await this.excelRepository.loadTemplate({ type: "file", file: excelFile });
         const template = await this.templateRepository.getTemplate(templateId);
 
         const dataFormId = await this.excelRepository.readCell(templateId, template.dataFormId, {

--- a/src/domain/usecases/AnalyzeTemplateUseCase.ts
+++ b/src/domain/usecases/AnalyzeTemplateUseCase.ts
@@ -1,5 +1,6 @@
 import { UseCase } from "../../CompositionRoot";
 import i18n from "../../locales";
+import { getExcelOrThrow } from "../../utils/files";
 import { ExcelReader } from "../helpers/ExcelReader";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
@@ -13,7 +14,12 @@ export class AnalyzeTemplateUseCase implements UseCase {
     ) {}
 
     public async execute(file: File) {
-        const templateId = await this.excelRepository.loadTemplate({ type: "file", file });
+        const excelFile = await getExcelOrThrow(file);
+
+        const templateId = await this.excelRepository.loadTemplate({
+            type: "file",
+            file: excelFile,
+        });
         const template = await this.templateRepository.getTemplate(templateId);
 
         const dataFormId = await this.excelRepository.readCell(templateId, template.dataFormId, {
@@ -45,7 +51,7 @@ export class AnalyzeTemplateUseCase implements UseCase {
             period,
         }));
 
-        return { custom: true, dataForm, dataValues, orgUnits };
+        return { custom: true, dataForm, dataValues, orgUnits, file };
     }
 }
 

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -14,6 +14,9 @@ import { ExcelReader } from "../helpers/ExcelReader";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
 import { TemplateRepository } from "../repositories/TemplateRepository";
+import { FileRepository } from "../repositories/FileRepository";
+import { FileResource } from "../entities/FileResource";
+import { extractImagesFromZip, getExcelOrThrow, isExcelFile } from "../../utils/files";
 
 export type ImportTemplateError =
     | {
@@ -43,7 +46,8 @@ export class ImportTemplateUseCase implements UseCase {
     constructor(
         private instanceRepository: InstanceRepository,
         private templateRepository: TemplateRepository,
-        private excelRepository: ExcelRepository
+        private excelRepository: ExcelRepository,
+        private fileRepository: FileRepository
     ) {}
 
     public async execute({
@@ -54,11 +58,13 @@ export class ImportTemplateUseCase implements UseCase {
         organisationUnitStrategy = "ERROR",
         settings,
     }: ImportTemplateUseCaseParams): Promise<Either<ImportTemplateError, SynchronizationResult[]>> {
+        const excelFile = await getExcelOrThrow(file);
+
         if (useBuilderOrgUnits && selectedOrgUnits.length !== 1) {
             return Either.error({ type: "INVALID_OVERRIDE_ORG_UNIT" });
         }
 
-        const templateId = await this.excelRepository.loadTemplate({ type: "file", file });
+        const templateId = await this.excelRepository.loadTemplate({ type: "file", file: excelFile });
         const template = await this.templateRepository.getTemplate(templateId);
 
         const dataFormId = removeCharacters(
@@ -80,13 +86,22 @@ export class ImportTemplateUseCase implements UseCase {
             return Either.error({ type: "MALFORMED_TEMPLATE" });
         }
 
+        const filesToUpload = isExcelFile(file.name)
+            ? []
+            : await extractImagesFromZip(file, {
+                  filesToExtract: this.getImageDataValuesOnly(dataPackage.dataEntries, dataForm),
+              });
+
+        const uploadedFiles = await this.fileRepository.uploadAll(filesToUpload);
+
         const { dataValues, invalidDataValues, existingDataValues, instanceDataValues } = await this.readDataValues(
             dataPackage,
             dataForm,
             useBuilderOrgUnits,
             selectedOrgUnits,
             settings,
-            duplicateStrategy
+            duplicateStrategy,
+            uploadedFiles
         );
 
         if (organisationUnitStrategy === "ERROR" && invalidDataValues.dataEntries.length > 0) {
@@ -137,7 +152,8 @@ export class ImportTemplateUseCase implements UseCase {
         useBuilderOrgUnits: boolean,
         selectedOrgUnits: string[],
         settings: Settings,
-        duplicateStrategy: DuplicateImportStrategy
+        duplicateStrategy: DuplicateImportStrategy,
+        files: FileResource[]
     ) {
         const { duplicateEnabled, duplicateExclusion, duplicateTolerance, duplicateToleranceUnit } = settings;
 
@@ -183,7 +199,7 @@ export class ImportTemplateUseCase implements UseCase {
         return {
             dataValues: {
                 type: dataForm.type,
-                dataEntries: excelFile,
+                dataEntries: files.length === 0 ? excelFile : this.addImagesToDataEntries(files, excelFile, dataForm),
                 trackedEntityInstances,
             },
             invalidDataValues: {
@@ -202,6 +218,43 @@ export class ImportTemplateUseCase implements UseCase {
                 trackedEntityInstances: [],
             },
         };
+    }
+
+    private addImagesToDataEntries(files: FileResource[], dataEntries: DataPackageData[], dataForm: DataForm) {
+        const imageDataElementsIds = this.getImageDataElementIds(dataForm);
+        return dataEntries.map(dataEntry => {
+            return {
+                ...dataEntry,
+                dataValues: dataEntry.dataValues.map(dataValue => {
+                    if (!imageDataElementsIds.includes(dataValue.dataElement)) {
+                        return dataValue;
+                    }
+                    const fileInfo = files.find(
+                        file => file.name.toLowerCase() === String(dataValue.value).toLowerCase()
+                    );
+                    return {
+                        ...dataValue,
+                        value: fileInfo?.id || "",
+                    };
+                }),
+            };
+        });
+    }
+
+    private getImageDataValuesOnly(dataEntries: DataPackageData[], dataForm: DataForm) {
+        const imageDataElementsIds = this.getImageDataElementIds(dataForm);
+        const fileNameInDataValues = _(dataEntries)
+            .flatMap(de => de.dataValues)
+            .filter(dv => imageDataElementsIds.includes(dv.dataElement))
+            .map(dv => String(dv.value))
+            .compact()
+            .value();
+
+        return fileNameInDataValues;
+    }
+
+    private getImageDataElementIds(dataForm: DataForm) {
+        return dataForm.dataElements.filter(de => de.valueType === "IMAGE").map(de => de.id);
     }
 
     private parseExcelFile(dataPackage: DataPackage, useBuilderOrgUnits: boolean, selectedOrgUnits: string[]) {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -3,9 +3,6 @@ import _ from "lodash";
 import { FileResource } from "../domain/entities/FileResource";
 
 type ExtensionName = string;
-type ExtractFileOptions = {
-    filesToExtract: string[];
-};
 
 const ALLOWED_IMAGES = ["png", "jpg", "jpeg", "svg"];
 const XLSX_EXTENSION = "xlsx";
@@ -69,28 +66,11 @@ export async function extractExcelFromZip(file: File) {
     return await zipContent.file(excelFileName)?.async("blob");
 }
 
-export async function extractImagesFromZip(file: File, options: ExtractFileOptions): Promise<FileResource[]> {
-    const { filesToExtract } = options;
+export async function extractImagesFromZip(file: File): Promise<FileResource[]> {
     const zip = new JSZip();
     const zipContent = await zip.loadAsync(file);
 
     const fileNames = _(zipContent.files).keys().value();
-
-    const fileNamesImages = _(fileNames)
-        .map(fileName => {
-            const extensionFile = _(fileName).split(".").last()?.toLowerCase() || "";
-            const name = _(fileName).split("/").last() || "";
-            return ALLOWED_IMAGES.includes(extensionFile) ? name : undefined;
-        })
-        .compact()
-        .value();
-
-    const fileNotInZip = _.differenceBy(filesToExtract, fileNamesImages);
-    if (fileNotInZip.length > 0) {
-        console.error(_.differenceBy(filesToExtract, fileNamesImages));
-        const message = `Cannot found files: ${fileNotInZip.join(", ")} in zip.`;
-        throw new Error(message);
-    }
 
     const allowedFiles = _(fileNames)
         .map(fileName => {
@@ -99,7 +79,6 @@ export async function extractImagesFromZip(file: File, options: ExtractFileOptio
             return ALLOWED_IMAGES.includes(extensionFile) ? name : undefined;
         })
         .compact()
-        .filter(fileName => filesToExtract.includes(fileName))
         .value();
 
     const promises = _(allowedFiles)

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,3 +1,21 @@
+import JSZip from "jszip";
+import _ from "lodash";
+import { FileResource } from "../domain/entities/FileResource";
+
+type ExtensionName = string;
+type ExtractFileOptions = {
+    filesToExtract: string[];
+};
+
+const ALLOWED_IMAGES = ["png", "jpg", "jpeg", "svg"];
+const XLSX_EXTENSION = "xlsx";
+const MIME_TYPES_BY_EXTENSION: Record<ExtensionName, string> = {
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    png: "image/png",
+    svg: "image/svg+xml",
+};
+
 export const toBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();
@@ -25,6 +43,95 @@ export const fromBase64 = async (uri: string, filename?: string, options?: { mim
 export function getBlobFromBase64(contents: string): Blob {
     const buffer = Buffer.from(contents, "base64");
     return new Blob([buffer]);
+}
+
+export function isExcelFile(fileName: string): boolean {
+    return getExtensionFile(fileName) === XLSX_EXTENSION;
+}
+
+function getExtensionFile(fileName: string) {
+    return _(fileName).split(".").last()?.toLowerCase();
+}
+
+export async function extractExcelFromZip(file: File) {
+    const zip = new JSZip();
+
+    const zipContent = await zip.loadAsync(file);
+
+    const fileNames = _(zipContent.files).keys().value();
+
+    const excelFileName =
+        _(fileNames).find(fileName => {
+            const extensionFile = _(fileName).split(".").last()?.toLowerCase() || "";
+            return extensionFile === XLSX_EXTENSION;
+        }) || "";
+
+    return await zipContent.file(excelFileName)?.async("blob");
+}
+
+export async function extractImagesFromZip(file: File, options: ExtractFileOptions): Promise<FileResource[]> {
+    const { filesToExtract } = options;
+    const zip = new JSZip();
+    const zipContent = await zip.loadAsync(file);
+
+    const fileNames = _(zipContent.files).keys().value();
+
+    const fileNamesImages = _(fileNames)
+        .map(fileName => {
+            const extensionFile = _(fileName).split(".").last()?.toLowerCase() || "";
+            const name = _(fileName).split("/").last() || "";
+            return ALLOWED_IMAGES.includes(extensionFile) ? name : undefined;
+        })
+        .compact()
+        .value();
+
+    const fileNotInZip = _.differenceBy(filesToExtract, fileNamesImages);
+    if (fileNotInZip.length > 0) {
+        console.error(_.differenceBy(filesToExtract, fileNamesImages));
+        const message = `Cannot found files: ${fileNotInZip.join(", ")} in zip.`;
+        throw new Error(message);
+    }
+
+    const allowedFiles = _(fileNames)
+        .map(fileName => {
+            const extensionFile = _(fileName).split(".").last()?.toLowerCase() || "";
+            const name = _(fileName).split("/").last() || "";
+            return ALLOWED_IMAGES.includes(extensionFile) ? name : undefined;
+        })
+        .compact()
+        .filter(fileName => filesToExtract.includes(fileName))
+        .value();
+
+    const promises = _(allowedFiles)
+        .map(fileName => {
+            return zipContent.file(fileName)?.async("blob");
+        })
+        .value();
+
+    const filesContents = await Promise.all(promises);
+
+    return _(filesContents)
+        .map((fileContent, index) => {
+            if (!fileContent) return undefined;
+            const name = allowedFiles[index] || "";
+            return {
+                id: "",
+                data: fileContent.slice(0, fileContent.size, MIME_TYPES_BY_EXTENSION[getExtensionFile(name) as string]),
+                name,
+            };
+        })
+        .compact()
+        .value();
+}
+
+export async function getExcelOrThrow(file: File) {
+    const isExcel = isExcelFile(file.name);
+    const excelFile = isExcel ? file : await extractExcelFromZip(file);
+    if (excelFile) {
+        return excelFile;
+    } else {
+        throw new Error("Zip file does not have a xlsx file");
+    }
 }
 
 export const xlsxMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";

--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -272,9 +272,12 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
             <h3>{i18n.t("Bulk data import")}</h3>
 
             <Dropzone
-                accept={
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel.sheet.macroEnabled.12"
-                }
+                accept={[
+                    "application/zip",
+                    "application/x-zip-compressed",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "application/vnd.ms-excel.sheet.macroEnabled.12",
+                ]}
                 onDrop={onDrop}
                 multiple={false}
             >


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865cm2c33

### :memo: Implementation

I tried to use d2-api, [but the domain is hardcoded to **"DOCUMENT"**](https://github.com/EyeSeeTea/d2-api/blob/master/src/api/files.ts#L43) and for this case it must be **"DATA_VALUE"**

### :fire: Notes for the reviewer

Zip file for testing: [test-full.zip](https://github.com/EyeSeeTea/Bulk-Load/files/11886882/test-full.zip)

Docker: [docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-test](docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-test)

### :art: Screenshots

**Excel with filenames for before/after datavalue**
![excel-file-names](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/240aa76c-12d3-4f82-9976-70217b97482b)

**Support for zip files**
![zip-support](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/13da6d4b-56b1-4a1f-b16d-709ca8750eee)

**Tracker with images from zip file**
![tracker-event-images](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/f475b21a-131b-4f15-b63c-7c3c9d6bdd0a)

### :bookmark_tabs: Others
