### PR TITLE
feat: upload teis and events in chunks

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -43,14 +43,16 @@ import { D2Api } from "./types/d2-api";
 import { GetFilteredThemesUseCase } from "./domain/usecases/GetFilteredThemesUseCase";
 import { FileD2Repository } from "./data/FileD2Repository";
 import { ImportSourceZipRepository } from "./data/ImportSourceZipRepository";
+import { ImportSourceNodeRepository } from "./data/ImportSourceNodeRepository";
 
 export interface CompositionRootOptions {
     appConfig: JsonConfig;
     dhisInstance: DhisInstance;
     mockApi?: D2Api;
+    importSource?: "zip" | "node";
 }
 
-export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: CompositionRootOptions) {
+export function getCompositionRoot({ appConfig, dhisInstance, mockApi, importSource = "zip" }: CompositionRootOptions) {
     const instance: InstanceRepository = new InstanceDhisRepository(dhisInstance, mockApi);
     const config: ConfigRepository = new ConfigWebRepository(appConfig);
     const storage: StorageRepository =
@@ -62,7 +64,8 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi }: Composi
     const migrations: MigrationsRepository = new MigrationsAppRepository(storage, dhisInstance);
     const usersRepository = new D2UsersRepository(dhisInstance);
     const fileRepository = new FileD2Repository(dhisInstance);
-    const importSourceRepository = new ImportSourceZipRepository();
+    const importSourceRepository =
+        importSource === "zip" ? new ImportSourceZipRepository() : new ImportSourceNodeRepository();
 
     return {
         orgUnits: getExecute({

--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -1,13 +1,18 @@
+import _ from "lodash";
 import { D2Api } from "../types/d2-api";
 import { Event } from "../domain/entities/DhisDataPackage";
 import { SynchronizationResult } from "../domain/entities/SynchronizationResult";
 import { ImportPostResponse, postImport } from "./Dhis2Import";
 import i18n from "../locales";
+import { promiseMap } from "../utils/promises";
 
-export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult> {
-    return postImport(() => api.post<ImportPostResponse>("/events", {}, { events }).getData(), {
-        title: i18n.t("Data values - Create/update"),
-        model: i18n.t("Event"),
-        splitStatsList: true,
+export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult[]> {
+    const eventsResult = await promiseMap(_.chunk(events, 200), eventsToSave => {
+        return postImport(() => api.post<ImportPostResponse>("/events", {}, { events: eventsToSave }).getData(), {
+            title: i18n.t("Data values - Create/update"),
+            model: i18n.t("Event"),
+            splitStatsList: true,
+        });
     });
+    return eventsResult;
 }

--- a/src/data/ImportSourceNodeRepository.ts
+++ b/src/data/ImportSourceNodeRepository.ts
@@ -1,0 +1,8 @@
+import { ImportSource } from "../domain/entities/FileResource";
+import { ImportSourceRepository } from "../domain/repositories/ImportSourceRepository";
+
+export class ImportSourceNodeRepository implements ImportSourceRepository {
+    async import(blob: Blob): Promise<ImportSource> {
+        return { images: [], spreadSheet: blob };
+    }
+}

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -209,7 +209,7 @@ export class InstanceDhisRepository implements InstanceRepository {
             }
             case "programs": {
                 const result = await this.importEventsData(dataPackage);
-                return [result];
+                return result;
             }
             case "trackerPrograms": {
                 return this.importTrackerProgramData(dataPackage);
@@ -416,7 +416,7 @@ export class InstanceDhisRepository implements InstanceRepository {
         );
     }
 
-    private async importEventsData(dataPackage: DataPackage): Promise<SynchronizationResult> {
+    private async importEventsData(dataPackage: DataPackage): Promise<SynchronizationResult[]> {
         const events = this.buildEventsPayload(dataPackage);
         return postEvents(this.api, events);
     }

--- a/src/domain/repositories/ImportSourceRepository.ts
+++ b/src/domain/repositories/ImportSourceRepository.ts
@@ -2,4 +2,5 @@ import { ImportSource } from "../entities/FileResource";
 
 export interface ImportSourceRepository {
     import(file: File): Promise<ImportSource>;
+    import(file: Blob): Promise<ImportSource>;
 }

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -16,7 +16,6 @@ import { InstanceRepository } from "../repositories/InstanceRepository";
 import { TemplateRepository } from "../repositories/TemplateRepository";
 import { FileRepository } from "../repositories/FileRepository";
 import { FileResource } from "../entities/FileResource";
-import { isExcelFile } from "../../utils/files";
 import { ImportSourceRepository } from "../repositories/ImportSourceRepository";
 import { TrackedEntityInstance } from "../entities/TrackedEntityInstance";
 
@@ -89,9 +88,8 @@ export class ImportTemplateUseCase implements UseCase {
             return Either.error({ type: "MALFORMED_TEMPLATE" });
         }
 
-        const filesToUpload = isExcelFile(file.name)
-            ? []
-            : this.validateImagesExistInZip(dataPackage.dataEntries, dataForm, images);
+        const filesToUpload =
+            images.length === 0 ? [] : this.validateImagesExistInZip(dataPackage.dataEntries, dataForm, images);
 
         const uploadedFiles = await this.fileRepository.uploadAll(filesToUpload);
 

--- a/src/scripts/import-multiple-files.ts
+++ b/src/scripts/import-multiple-files.ts
@@ -1,8 +1,8 @@
 import _ from "lodash";
 import path from "path";
 import { command, run, string, option } from "cmd-ts";
-import { resolve } from "node:path";
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve, basename } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
 
 import { D2Api } from "./../types/d2-api";
 import appConfig from "../../public/app-config.json";
@@ -10,30 +10,6 @@ import { getCompositionRoot } from "../CompositionRoot";
 import { JsonConfig } from "../data/ConfigWebRepository";
 import { getD2APiFromInstance } from "../utils/d2-api";
 import Settings from "../webapp/logic/settings";
-import { promiseMap } from "../utils/promises";
-import { isExcelFile } from "../utils/files";
-
-type BufferWithFileName = {
-    content: Buffer;
-    fileName: string;
-};
-
-async function readExcelFilesInFolder(fullPathFolder: string): Promise<BufferWithFileName[]> {
-    const fileNames = await readdir(fullPathFolder);
-    console.debug(`Looking for excel files in: ${fullPathFolder}`);
-    const filesContent = await promiseMap(fileNames, async fileName => {
-        const filePath = resolve(fullPathFolder, fileName);
-        const content = isExcelFile(fileName) ? await readFile(filePath) : undefined;
-        if (!content) return undefined;
-        return {
-            content,
-            fileName,
-        };
-    });
-    const excelFiles = _(filesContent).compact().value();
-    console.debug(`${excelFiles.length} excel files found.`);
-    return excelFiles;
-}
 
 function main() {
     const cmd = command({
@@ -60,38 +36,35 @@ function main() {
             }),
         },
         handler: async args => {
-            const filesContent = await readExcelFilesInFolder(args.folderPath);
             const api: D2Api = getD2APiFromInstance({ type: "local", url: args.url });
 
-            await promiseMap(filesContent, async file => {
-                const compositionRoot = getCompositionRoot({
-                    appConfig: appConfig as unknown as JsonConfig,
-                    dhisInstance: { type: "local", url: args.url },
-                    importSource: "node",
-                });
-                const settings = await Settings.build(api, compositionRoot);
-                console.debug(`Importing file ${file.fileName}`);
-                const results = await compositionRoot.templates.import({
-                    // @ts-ignore
-                    file: file.content,
-                    settings,
-                    duplicateStrategy: "ERROR",
-                    organisationUnitStrategy: "ERROR",
-                    selectedOrgUnits: [],
-                    useBuilderOrgUnits: false,
-                });
-                const resultPath = resolve(args.resultsPath, `${file.fileName}.json`);
-                results.match({
-                    success: async syncResults => {
-                        const resultDetails = JSON.stringify(syncResults, null, 2);
-                        await writeFile(resultPath, resultDetails);
-                        console.debug(`Results saved to ${resultPath}`);
-                    },
-                    error: async errorResults => {
-                        await writeFile(resultPath, errorResults.type);
-                    },
-                });
-                return results;
+            const excelFile = await readFile(args.folderPath);
+            const compositionRoot = getCompositionRoot({
+                appConfig: appConfig as unknown as JsonConfig,
+                dhisInstance: { type: "local", url: args.url },
+                importSource: "node",
+            });
+            const settings = await Settings.build(api, compositionRoot);
+            console.debug(`Importing file ${args.folderPath}`);
+            const results = await compositionRoot.templates.import({
+                // @ts-ignore
+                file: Buffer.from(excelFile),
+                settings,
+                duplicateStrategy: "ERROR",
+                organisationUnitStrategy: "ERROR",
+                selectedOrgUnits: [],
+                useBuilderOrgUnits: false,
+            });
+            const resultPath = resolve(args.resultsPath, `${basename(args.folderPath)}.json`);
+            results.match({
+                success: async syncResults => {
+                    const resultDetails = JSON.stringify(syncResults, null, 2);
+                    await writeFile(resultPath, resultDetails);
+                    console.debug(`Results saved to ${resultPath}`);
+                },
+                error: async errorResults => {
+                    await writeFile(resultPath, errorResults.type);
+                },
             });
         },
     });

--- a/src/scripts/import-multiple-files.ts
+++ b/src/scripts/import-multiple-files.ts
@@ -1,0 +1,102 @@
+import _ from "lodash";
+import path from "path";
+import { command, run, string, option } from "cmd-ts";
+import { resolve } from "node:path";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+
+import { D2Api } from "./../types/d2-api";
+import appConfig from "../../public/app-config.json";
+import { getCompositionRoot } from "../CompositionRoot";
+import { JsonConfig } from "../data/ConfigWebRepository";
+import { getD2APiFromInstance } from "../utils/d2-api";
+import Settings from "../webapp/logic/settings";
+import { promiseMap } from "../utils/promises";
+import { isExcelFile } from "../utils/files";
+
+type BufferWithFileName = {
+    content: Buffer;
+    fileName: string;
+};
+
+async function readExcelFilesInFolder(fullPathFolder: string): Promise<BufferWithFileName[]> {
+    const fileNames = await readdir(fullPathFolder);
+    console.debug(`Looking for excel files in: ${fullPathFolder}`);
+    const filesContent = await promiseMap(fileNames, async fileName => {
+        const filePath = resolve(fullPathFolder, fileName);
+        const content = isExcelFile(fileName) ? await readFile(filePath) : undefined;
+        if (!content) return undefined;
+        return {
+            content,
+            fileName,
+        };
+    });
+    const excelFiles = _(filesContent).compact().value();
+    console.debug(`${excelFiles.length} excel files found.`);
+    return excelFiles;
+}
+
+function main() {
+    const cmd = command({
+        name: path.basename(__filename),
+        description: "Import data from multiples excel files",
+        args: {
+            url: option({
+                type: string,
+                short: "u",
+                long: "dhis2-url",
+                description: "DHIS2 base URL. Example: http://USERNAME:PASSWORD@localhost:8080",
+            }),
+            folderPath: option({
+                type: string,
+                short: "fp",
+                long: "folder-path",
+                description: "folder path with excel files to import data",
+            }),
+            resultsPath: option({
+                type: string,
+                short: "rp",
+                long: "results-path",
+                description: "folder where import results will be saved",
+            }),
+        },
+        handler: async args => {
+            const filesContent = await readExcelFilesInFolder(args.folderPath);
+            const api: D2Api = getD2APiFromInstance({ type: "local", url: args.url });
+
+            await promiseMap(filesContent, async file => {
+                const compositionRoot = getCompositionRoot({
+                    appConfig: appConfig as unknown as JsonConfig,
+                    dhisInstance: { type: "local", url: args.url },
+                    importSource: "node",
+                });
+                const settings = await Settings.build(api, compositionRoot);
+                console.debug(`Importing file ${file.fileName}`);
+                const results = await compositionRoot.templates.import({
+                    // @ts-ignore
+                    file: file.content,
+                    settings,
+                    duplicateStrategy: "ERROR",
+                    organisationUnitStrategy: "ERROR",
+                    selectedOrgUnits: [],
+                    useBuilderOrgUnits: false,
+                });
+                const resultPath = resolve(args.resultsPath, `${file.fileName}.json`);
+                results.match({
+                    success: async syncResults => {
+                        const resultDetails = JSON.stringify(syncResults, null, 2);
+                        await writeFile(resultPath, resultDetails);
+                        console.debug(`Results saved to ${resultPath}`);
+                    },
+                    error: async errorResults => {
+                        await writeFile(resultPath, errorResults.type);
+                    },
+                });
+                return results;
+            });
+        },
+    });
+
+    run(cmd, process.argv.slice(2));
+}
+
+main();


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865ct86pm

### :memo: Implementation

Right now current implementation of the import data works with the [web File API](https://developer.mozilla.org/en-US/docs/Web/API/File). Since nodejs does not have support for that I tried to mimic but then I got different errors on the import process. I'm disabling TS check for that particular parameter and passing a buffer instead a File and it's working well. 

### :fire: Notes for the reviewer

Script to upload multiple excel files can be executed using the following command:

```bash
npx ts-node src/scripts/import-multiple-files.ts \
--dhis2-url 'http://user:password@localhost:8080' \
--folder-path /home/bulkloadtemplates \
--results-path /home/bulkloadjsonresults
```

The `folder-path` must contains all the excel files to be imported.
The `results-path` can be an empty folder. Sync results will be saved in there as a json file.

### :art: Screenshots

Query with the number of TEIS and EVENTS imported
[micro_batch_230713.xlsx](https://github.com/EyeSeeTea/Bulk-Load/files/12404207/micro_batch_230713.xlsx)

![result](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/bd3ed14f-9e26-4580-b4e4-8f462be96d20)

### :bookmark_tabs: Others
