### PR TITLE
Support for excel files with macros

### DIFF
--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -6,6 +6,7 @@ import { UseCase } from "../../CompositionRoot";
 import { getRelationshipMetadata, RelationshipOrgUnitFilter } from "../../data/Dhis2RelationshipTypes";
 import i18n from "../../locales";
 import { D2Api } from "../../types/d2-api";
+import { getExtensionFile, XLSX_EXTENSION } from "../../utils/files";
 import { promiseMap } from "../../utils/promises";
 import Settings from "../../webapp/logic/settings";
 import { getGeneratedTemplateId, SheetBuilder } from "../../webapp/logic/sheetBuilder";
@@ -158,7 +159,8 @@ export class DownloadTemplateUseCase implements UseCase {
             await builder.populateTemplate(template, dataPackage, settings);
         }
 
-        const filename = `${name}.xlsx`;
+        const extension = template.type === "custom" ? getExtensionFile(template.file.name) : XLSX_EXTENSION;
+        const filename = `${name}.${extension}`;
 
         if (writeFile) {
             const buffer = await this.excelRepository.toBuffer(templateId);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -4,13 +4,20 @@ import { FileResource } from "../domain/entities/FileResource";
 
 type ExtensionName = string;
 
+export const xlsxMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+export const xlsxMacroMimeType = "application/vnd.ms-excel.sheet.macroEnabled.12";
+
 const ALLOWED_IMAGES = ["png", "jpg", "jpeg", "svg"];
-const XLSX_EXTENSION = "xlsx";
-const MIME_TYPES_BY_EXTENSION: Record<ExtensionName, string> = {
+export const XLSX_EXTENSION = "xlsx";
+const XLSX_EXTENSION_WITH_MACRO = "xlsm";
+export const MIME_TYPES_BY_EXTENSION: Record<ExtensionName, string> = {
     jpeg: "image/jpeg",
     jpg: "image/jpeg",
     png: "image/png",
     svg: "image/svg+xml",
+    json: "application/json",
+    XLSX_EXTENSION: xlsxMimeType,
+    XLSX_EXTENSION_WITH_MACRO: xlsxMacroMimeType,
 };
 
 export const toBase64 = (file: File): Promise<string> => {
@@ -43,10 +50,11 @@ export function getBlobFromBase64(contents: string): Blob {
 }
 
 export function isExcelFile(fileName: string): boolean {
-    return getExtensionFile(fileName) === XLSX_EXTENSION;
+    const extension = getExtensionFile(fileName);
+    return extension === XLSX_EXTENSION || extension === XLSX_EXTENSION_WITH_MACRO;
 }
 
-function getExtensionFile(fileName: string) {
+export function getExtensionFile(fileName: string) {
     return _(fileName).split(".").last()?.toLowerCase();
 }
 
@@ -59,8 +67,7 @@ export async function extractExcelFromZip(file: File) {
 
     const excelFileName =
         _(fileNames).find(fileName => {
-            const extensionFile = _(fileName).split(".").last()?.toLowerCase() || "";
-            return extensionFile === XLSX_EXTENSION;
+            return isExcelFile(fileName);
         }) || "";
 
     return await zipContent.file(excelFileName)?.async("blob");
@@ -112,5 +119,3 @@ export async function getExcelOrThrow(file: File) {
         throw new Error("Zip file does not have a xlsx file");
     }
 }
-
-export const xlsxMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";

--- a/src/webapp/components/settings/TemplateEditDialog.tsx
+++ b/src/webapp/components/settings/TemplateEditDialog.tsx
@@ -25,7 +25,7 @@ import {
 } from "./templates/TemplateView";
 import { downloadFile } from "../../utils/download";
 import { useAppContext } from "../../contexts/app-context";
-import { xlsxMimeType } from "../../../utils/files";
+import { getExtensionFile, MIME_TYPES_BY_EXTENSION, xlsxMacroMimeType, xlsxMimeType } from "../../../utils/files";
 
 export interface CustomTemplateEditDialogProps {
     formMode: FormMode;
@@ -192,7 +192,7 @@ const EditDialog: React.FC<CustomTemplateEditDialogProps2> = React.memo(props =>
                 </Group>
 
                 <Group title={i18n.t("File")}>
-                    <FileField data={data} field="spreadsheet" mimeType={xlsxMimeType} />
+                    <FileField data={data} field="spreadsheet" mimeType={[xlsxMimeType, xlsxMacroMimeType]} />
                 </Group>
             </Div>
         </ConfirmationDialog>
@@ -208,7 +208,7 @@ const stylesFields = {
 const FileField: React.FC<{
     data: { template: ViewModel; setTemplate: SetTemplate };
     field: "spreadsheet" | "dataSources" | "styleSources";
-    mimeType: string;
+    mimeType: string | string[];
 }> = React.memo(props => {
     const { data, field, mimeType } = props;
     const { template, setTemplate } = data;
@@ -226,10 +226,13 @@ const FileField: React.FC<{
     const download = React.useCallback<NonNullable<ButtonProps["onClick"]>>(
         ev => {
             if (!file) return;
+            const extensionFile = getExtensionFile(file.name);
+            if (!extensionFile) return;
+            const fileMimeType = MIME_TYPES_BY_EXTENSION[extensionFile] || file.type;
             ev.stopPropagation();
-            downloadFile({ filename: file.name, data: file, mimeType });
+            downloadFile({ filename: file.name, data: file, mimeType: fileMimeType });
         },
-        [file, mimeType]
+        [file]
     );
 
     const { getRootProps, getInputProps } = useDropzone({ onDrop, accept: mimeType, multiple: false });


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/860rp7h7k

### :memo: Implementation

We need to add support for files with extension `xlsm` because for NHWA Module 1 we need a dropdown list with multiple selection. Something that is not supported out of the box in excel, but can be enabled with macros.

### :fire: Notes for the reviewer

Please download the new template with macros from the clickup issue

### :video_camera: Screenshots/Screen capture

**Import Data Screen**
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/f3d94cfa-bafb-4218-b5db-8b9614c3acf8)

**Edit Custom Template Modal**
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/d4a5948f-a572-4c06-8f6e-940946944905)
