### PR TITLE
Add org units selector for DE of type ORGANISATION_UNIT

### DIFF
--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -968,7 +968,9 @@ export class SheetBuilder {
                             columnId,
                             `_${dataElement.id}`,
                             groupId,
-                            this.validations.get(validation)
+                            dataElement.valueType === "ORGANISATION_UNIT"
+                                ? this.validations.get("organisationUnits")
+                                : this.validations.get(validation)
                         );
                         dataEntrySheet.column(columnId).setWidth(name.length / 2.5 + 10);
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/860rttvpf

### :memo: Implementation

- Reuse org. units that have been selected for the template in data elements with `valueType ORGANISATION_UNIT`

### :fire: Notes for the reviewer

You can use the [program `AMR_GLASS_EGASP_PRE_INPUT_FILES`](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/programSection/program/SOjanrinfuG) for testing. Check that the program has the [`AMR_GLASS_EGASP_DET_LAB_ID` data element](https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/dataElementSection/dataElement/J4c6Fxy7wQW). 

### :video_camera: Screenshots/Screen capture

Template
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/b1ecdc0d-c80d-4f59-8ea3-f07f652097af)

Importing Data

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/66e978b9-c897-444e-93fe-9d9f09ef9e40)

Event in Capture App

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/332cb4c8-6650-4973-acb7-07f240c18d01)


### :bookmark_tabs: Others
