### PR TITLE
add import mode to update datasets without deleting existing data

### DIFF
--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -201,10 +201,16 @@ export class InstanceDhisRepository implements InstanceRepository {
         return this.importAggregatedData("DELETE", dataPackage);
     }
 
-    public async importDataPackage(dataPackage: DataPackage): Promise<SynchronizationResult[]> {
+    public async importDataPackage(
+        dataPackage: DataPackage,
+        createAndUpdate: boolean
+    ): Promise<SynchronizationResult[]> {
         switch (dataPackage.type) {
             case "dataSets": {
-                const result = await this.importAggregatedData("CREATE_AND_UPDATE", dataPackage);
+                const result = await this.importAggregatedData(
+                    createAndUpdate ? "CREATE_AND_UPDATE" : "CREATE",
+                    dataPackage
+                );
                 return [result];
             }
             case "programs": {

--- a/src/domain/repositories/InstanceRepository.ts
+++ b/src/domain/repositories/InstanceRepository.ts
@@ -37,7 +37,7 @@ export interface InstanceRepository {
     getLocales(): Promise<Locale[]>;
     getDefaultIds(filter?: string): Promise<string[]>;
     deleteAggregatedData(dataPackage: DataPackage): Promise<SynchronizationResult>;
-    importDataPackage(dataPackage: DataPackage): Promise<SynchronizationResult[]>;
+    importDataPackage(dataPackage: DataPackage, createAndUpdate: boolean): Promise<SynchronizationResult[]>;
     getProgram(programId: Id): Promise<Program | undefined>;
     convertDataPackage(dataPackage: DataPackage): EventsPackage | AggregatedPackage;
     getBuilderMetadata(teis: TrackedEntityInstance[]): Promise<BuilderMetadata>;

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -32,7 +32,7 @@ export type ImportTemplateError =
           instanceDataValues: DataPackage;
       };
 
-export type DuplicateImportStrategy = "ERROR" | "IMPORT" | "IGNORE";
+export type DuplicateImportStrategy = "ERROR" | "IMPORT" | "IGNORE" | "IMPORT_WITHOUT_DELETE";
 export type OrganisationUnitImportStrategy = "ERROR" | "IGNORE";
 
 export interface ImportTemplateUseCaseParams {
@@ -141,12 +141,17 @@ export class ImportTemplateUseCase implements UseCase {
             });
         }
 
-        const deleteResult =
-            duplicateStrategy === "IGNORE" || dataForm.type !== "dataSets"
-                ? undefined
-                : await this.instanceRepository.deleteAggregatedData(instanceDataValues);
+        const shouldDeleteExistingData =
+            dataForm.type === "dataSets" ? this.shouldDeleteAggregatedData(duplicateStrategy) : false;
 
-        const importResult = await this.instanceRepository.importDataPackage(dataValues);
+        const deleteResult = shouldDeleteExistingData
+            ? await this.instanceRepository.deleteAggregatedData(instanceDataValues)
+            : undefined;
+
+        const importResult = await this.instanceRepository.importDataPackage(
+            dataValues,
+            duplicateStrategy === "IMPORT_WITHOUT_DELETE"
+        );
 
         const importResultHasErrors = importResult.flatMap(result => result.errors);
         if (importResultHasErrors.length > 0 || deleteResult) {
@@ -162,6 +167,14 @@ export class ImportTemplateUseCase implements UseCase {
             return Either.success(_.compact([deleteResultWithErrorsDetails, ...importResultWithErrorsDetails]));
         } else {
             return Either.success(_.compact([deleteResult, ...importResult]));
+        }
+    }
+
+    private shouldDeleteAggregatedData(strategy: DuplicateImportStrategy): boolean {
+        if (strategy === "IMPORT") {
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -255,7 +268,7 @@ export class ImportTemplateUseCase implements UseCase {
         );
 
         const existingDataValues =
-            duplicateStrategy === "IMPORT"
+            duplicateStrategy === "IMPORT_WITHOUT_DELETE" || duplicateStrategy === "IMPORT"
                 ? []
                 : _.remove(excelFile, base => {
                       return instanceDataValues.find(dataPackage =>

--- a/src/webapp/components/modal-dialog/ModalDialog.tsx
+++ b/src/webapp/components/modal-dialog/ModalDialog.tsx
@@ -1,0 +1,107 @@
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogProps,
+    DialogTitle,
+    makeStyles,
+    Tooltip,
+} from "@material-ui/core";
+import _ from "lodash";
+import React from "react";
+
+import i18n from "../../../locales";
+
+export interface ModalDialogProps extends Partial<Omit<DialogProps, "title">> {
+    isOpen?: boolean;
+    title?: string;
+    description?: string;
+    onSave?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onCancel?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onInfoAction?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onUpdate?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    saveText?: string;
+    cancelText?: string;
+    infoActionText?: string;
+    disableSave?: boolean;
+    updateText?: string;
+    saveButtonPrimary?: boolean;
+    saveTooltipText?: string;
+    updateTooltipText?: string;
+    infoTooltipText?: string;
+}
+
+export const ModalDialog: React.FC<ModalDialogProps> = ({
+    title = "",
+    description,
+    onSave,
+    onUpdate,
+    onCancel,
+    onInfoAction,
+    isOpen = false,
+    children,
+    cancelText = i18n.t("Cancel"),
+    saveText = i18n.t("Save"),
+    updateText,
+    infoActionText = i18n.t("Info"),
+    disableSave = false,
+    saveButtonPrimary = true,
+    saveTooltipText = "",
+    updateTooltipText = "",
+    infoTooltipText = "",
+    ...other
+}) => {
+    const classes = useStyles();
+
+    return (
+        <Dialog open={isOpen} onClose={onCancel || _.noop} {...other}>
+            <DialogTitle>{title}</DialogTitle>
+
+            <DialogContent>
+                {description}
+                {children}
+            </DialogContent>
+
+            <DialogActions>
+                {onInfoAction && (
+                    <Tooltip placement="top" title={infoTooltipText}>
+                        <Button key={"info"} className={classes.infoButton} onClick={onInfoAction} autoFocus>
+                            {infoActionText}
+                        </Button>
+                    </Tooltip>
+                )}
+                {onCancel && (
+                    <Button key={"cancel"} onClick={onCancel} autoFocus>
+                        {cancelText}
+                    </Button>
+                )}
+                {onUpdate && (
+                    <Tooltip placement="top" title={updateTooltipText}>
+                        <Button key={"update"} onClick={onUpdate} color="primary">
+                            {updateText}
+                        </Button>
+                    </Tooltip>
+                )}
+                {onSave && (
+                    <Tooltip placement="top" title={saveTooltipText}>
+                        <Button
+                            key={"save"}
+                            onClick={onSave}
+                            color={saveButtonPrimary ? "primary" : "secondary"}
+                            disabled={disableSave}
+                        >
+                            {saveText}
+                        </Button>
+                    </Tooltip>
+                )}
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+const useStyles = makeStyles({
+    infoButton: { marginRight: "auto" },
+});
+
+export default ModalDialog;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/865d6pcu1

### :memo: Implementation

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

- New button to import data without deleting existing dataValues: **IMPORT AND UPDATE**
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/d542cfaf-a513-476f-942c-e8891f18d97b)

Help Message

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/2db451e8-86b0-414d-974a-eb62f172487b)

- DELETE AND IMPORT help message (previous **"PROCEED"**)
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/1d4af10f-fb9e-4462-8394-f21342f0ee8e)

- IMPORT ONLY NEW DATA VALUES help message
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/179f5f8e-94bf-48f9-b2ff-e6221f682b8d)

### :bookmark_tabs: Others