### PR TITLE
[refactor] Refactor boolean (yes/no) data values build

### DIFF
--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -19,6 +19,7 @@ import { FileRepository } from "../repositories/FileRepository";
 import { FileResource } from "../entities/FileResource";
 import { ImportSourceRepository } from "../repositories/ImportSourceRepository";
 import { TrackedEntityInstance } from "../entities/TrackedEntityInstance";
+import { Maybe } from "../../types/utils";
 
 export type ImportTemplateError =
     | {
@@ -518,12 +519,23 @@ export const compareDataPackages = (
     return true;
 };
 
+function getBooleanValue(item: DataPackageDataValue): Maybe<boolean> {
+    switch (true) {
+        case String(item.optionId) === "true" || item.optionId === "true":
+            return true;
+        case String(item.optionId) === "false" || item.optionId === "false":
+            return false;
+        default:
+            return undefined;
+    }
+}
+
 const formatDhis2Value = (item: DataPackageDataValue, dataForm: DataForm): DataPackageDataValue | undefined => {
     const dataElement = dataForm.dataElements.find(({ id }) => item.dataElement === id);
-    const booleanValue = String(item.optionId) === "true" || item.optionId === "true";
+    const booleanValue = getBooleanValue(item);
 
     if (dataElement?.valueType === "BOOLEAN") {
-        return { ...item, value: booleanValue };
+        return { ...item, value: booleanValue ?? "" };
     }
 
     if (dataElement?.valueType === "TRUE_ONLY") {

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -519,11 +519,20 @@ export const compareDataPackages = (
     return true;
 };
 
+const trueValues = ["y", "yes", "true", "1"];
+const falseValues = ["n", "no", "false", "0"];
+
 function getBooleanValue(item: DataPackageDataValue): Maybe<boolean> {
+    const strValue = String(item.value).toLowerCase();
+
     switch (true) {
         case String(item.optionId) === "true" || item.optionId === "true":
             return true;
         case String(item.optionId) === "false" || item.optionId === "false":
+            return false;
+        case trueValues.includes(strValue):
+            return true;
+        case falseValues.includes(strValue):
             return false;
         default:
             return undefined;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Required by https://app.clickup.com/t/8678yd6xd

### :memo: Implementation

- [x] Set no data value for empty boolean cells: For data values of type boolean (yes/no), an empty value would post a false value. That's not correct, it should be an empty value.
- [x] Consider heuristic string values for boolean cells. Booleans should be dropdown with values Yes/No, but some hand-generated sheets simply put "Yes"/"No" as strings. We add support for this case (true values: "y", "yes", "true", "1")