### PR TITLE
ignore empty string values in custom templates

### DIFF
--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -167,7 +167,7 @@ export class ExcelReader {
         const cell = await this.excelRepository.findRelativeCell(template.id, dataSource.ref);
         const value = cell ? await this.readCellValue(template, cell) : undefined;
         const optionId = await this.excelRepository.readCell(template.id, cell, { formula: true });
-        if (!isDefined(value)) return [];
+        if (!isDefined(value) || value === "") return [];
 
         const orgUnit = await this.readCellValue(template, dataSource.orgUnit);
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/862knky5u

### :memo: Implementation

Replacing the current formula for totals cells from: `=SUM(D9+D10+D17)` to `=IF(COUNT(E9,E10,E17)>0,SUM(E9,E10,E17),NA())`

With this we don't have by default the "0" value in all the cells that calculates totals. If there's no value in any of the cells that triggers the totals calculation the value for that cell will be `#N/A` (see screenshots section). That is going to be an empty value for bulk load therefore that cell will be ignored when user try to import the file.

### :fire: Notes for the reviewer

New template and datasource json attached in the issue.

### :art: Screenshots

![image](https://github.com/WISCENTD-UPC/Bulk-Load/assets/461124/1f8aa260-b543-477e-b757-b70e6226ef1c)

### :bookmark_tabs: Others
