### PR TITLE
adding support for financial period type

### DIFF
--- a/src/webapp/utils/period.ts
+++ b/src/webapp/utils/period.ts
@@ -1,0 +1,13 @@
+export function isFinancialPeriodType(periodType: FinancialPeriodType): boolean {
+    return periodType.startsWith("Financial");
+}
+
+export function getFinancialFormat(periodType: FinancialPeriodType): MomentUnitFormat {
+    return { unit: "years", format: `YYYY[${periodType.replace("Financial", "")}]` };
+}
+
+export type FinancialPeriodType = "FinancialApril" | "FinancialJuly" | "FinancialOct" | "FinancialNov";
+export type MomentUnitFormat = {
+    unit: string;
+    format: string;
+};

--- a/src/webapp/utils/periods.js
+++ b/src/webapp/utils/periods.js
@@ -1,7 +1,14 @@
 import moment from "moment";
+import { getFinancialFormat, isFinancialPeriodType } from "./period";
 
 export function buildAllPossiblePeriods(periodType, startDate, endDate) {
     let unit, format;
+
+    if (isFinancialPeriodType(periodType)) {
+        const financialUnitFormat = getFinancialFormat(periodType);
+        return generateDatesByPeriod({ startDate, endDate, ...financialUnitFormat });
+    }
+
     switch (periodType) {
         case "Daily":
             unit = "days";
@@ -27,10 +34,14 @@ export function buildAllPossiblePeriods(periodType, startDate, endDate) {
             throw new Error("Unsupported period type");
     }
 
+    return generateDatesByPeriod({ startDate, endDate, format, unit });
+}
+
+function generateDatesByPeriod(options) {
+    const { startDate, endDate, unit, format } = options;
     const dates = [];
     for (const current = moment(startDate); current.isSameOrBefore(moment(endDate)); current.add(1, unit)) {
         dates.push(current.format(format));
     }
-
     return dates;
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8693jz670

### :memo: Implementation

### :fire: Notes for the reviewer

Tested on [play demo 2.38.5.1](https://play.dhis2.org/2.38.5.1/dhis-web-maintenance/index.html#/edit/dataSetSection/dataSet/rsyjyJmYD4J) 

Template: [Expenditures.xlsx](https://github.com/EyeSeeTea/Bulk-Load/files/13981540/Expenditures.xlsx)

### :video_camera: Screenshots/Screen capture

**Financial Year periods in template:**

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/d9399cc6-b467-4703-875f-f2d7b2e323aa)

**Import Preview**

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/1e5cfe12-9579-4dea-b10d-d4f3dc64bd2c)

**Import Result**

![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/28591705-b1bf-4153-b65c-217b7267a564)

**Data Entry**
![image](https://github.com/EyeSeeTea/Bulk-Load/assets/461124/457ad5a6-ba48-4ee0-95c7-c7b71ccd38da)

