### PR TITLE
Fix duplicate event, update d2-api version, use new tracker api

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.3.3",
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
-        "@eyeseetea/d2-api": "1.11.0",
+        "@eyeseetea/d2-api": "1.13.2-beta.6",
         "@eyeseetea/d2-ui-components": "2.7.0-beta.3",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.12.3",

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -302,6 +302,9 @@ async function getConstraintForTypeProgram(
                 orgUnit: orgUnit.id,
                 startDate: startDate ? moment(startDate).format("YYYY-MM-DD") : undefined,
                 endDate: endDate ? moment(endDate).format("YYYY-MM-DD") : undefined,
+                fields: {
+                    $all: true,
+                },
             })
             .getData();
 

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -339,10 +339,10 @@ async function getApiEvents(
 
             return {
                 event: data.id,
-                trackedEntityInstance: teiId,
+                trackedEntity: teiId,
                 program: program,
                 orgUnit: data.orgUnit,
-                eventDate: data.period,
+                occurredAt: data.period,
                 attributeOptionCombo: data.attribute,
                 status: "COMPLETED" as const,
                 programStage: data.programStage,

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -25,7 +25,6 @@ import {
     DataStore,
     DataValueSetsGetResponse,
     Id,
-    Pager,
     SelectedPick,
 } from "../types/d2-api";
 import { cache } from "../utils/cache";

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -505,8 +505,8 @@ export class InstanceDhisRepository implements InstanceRepository {
                     pageSize: 250,
                     attributeCc: categoryComboId,
                     attributeCos: categoryOptionId,
-                    startDate: startDate?.format("YYYY-MM-DD"),
-                    endDate: endDate?.format("YYYY-MM-DD"),
+                    occurredAfter: startDate?.format("YYYY-MM-DD"),
+                    occurredBefore: endDate?.format("YYYY-MM-DD"),
                     cache: Math.random(),
                     // @ts-ignore FIXME: Add property in d2-api
                     fields: "*",

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -1,3 +1,5 @@
+import { D2Geometry } from "@eyeseetea/d2-api";
+
 export interface EventsPackage {
     events: Event[];
 }
@@ -21,13 +23,10 @@ export interface Event {
     orgUnit: string;
     program: string;
     status: string;
-    eventDate: string;
-    coordinate?: {
-        latitude: string;
-        longitude: string;
-    };
+    occurredAt: string;
+    geometry?: D2Geometry;
     attributeOptionCombo?: string;
-    trackedEntityInstance?: string;
+    trackedEntity?: string;
     programStage?: string;
     dataValues: EventDataValue[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.11.0.tgz#dc76fe0c0f00cc844b0326d740c03c15428fc362"
-  integrity sha512-zNIatB/MqKoSgrsOgIbDygIAKs0D1kEzHNxVA59+QqFOPXZ5l1p7GBrgjz8e/JkS/7KrvZWEnSqDku/o7eLRxg==
+"@eyeseetea/d2-api@1.13.2-beta.6":
+  version "1.13.2-beta.6"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.13.2-beta.6.tgz#e21c89f9e132bf8670a7b197b999ed25b89e2192"
+  integrity sha512-HPT5Q0+muLKBwlC6h5NwG/agQMWMcSxiN5uSVWCee42TfDf7o7bYAU78ly+1TE7kl2f7HBoYfdPVf7oKQ3kWUA==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"


### PR DESCRIPTION
### :pushpin: References 

* **Issue:** Closes [Downloading AMC Product Register data results in events duplicated](https://app.clickup.com/t/8693r9fav)

### :memo: Implementation

- This issue was only happening on the deprecated `api/events` endpoint. I've changed the GET events to the new `api/tracker/events`. For that, I had to update to the new version of d2-api (1.13.2-beta.6), and refactor some code based on the new endpoint.

### :fire: Notes for the reviewer

- To test, download a template for the program AMC - Product Register, on the orgUnit Burkina Faso, and populate the template from 01/02/24 to 27/02/24 for example. Before this fix, the events on the second tab came duplicated 5 times each, which was what the API wrongly fetched.

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others
