### PR TITLE
Fix coordinates import/export, use new tracker endpoint

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-06-29T07:07:25.389Z\n"
-"PO-Revision-Date: 2023-06-29T07:07:25.389Z\n"
+"POT-Creation-Date: 2024-03-08T12:55:49.199Z\n"
+"PO-Revision-Date: 2024-03-08T12:55:49.199Z\n"
 
 msgid "Data values - Create/update"
 msgstr ""
@@ -617,9 +617,6 @@ msgstr ""
 msgid "Value for field '{{field}}' is invalid - {{value}}"
 msgstr ""
 
-msgid "Imported"
-msgstr ""
-
 msgid "Updated"
 msgstr ""
 
@@ -641,6 +638,9 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
+msgid "Ids"
+msgstr ""
+
 msgid "Synchronization Results"
 msgstr ""
 
@@ -648,6 +648,9 @@ msgid "Status"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "Import was successful"
 msgstr ""
 
 msgid "Messages"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2023-06-29T07:07:25.389Z\n"
+"POT-Creation-Date: 2024-03-08T12:55:49.199Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -644,9 +644,6 @@ msgstr "Fuente de datos"
 msgid "Value for field '{{field}}' is invalid - {{value}}"
 msgstr ""
 
-msgid "Imported"
-msgstr "Importados"
-
 msgid "Updated"
 msgstr "Actualizados"
 
@@ -668,6 +665,9 @@ msgstr "Mensaje"
 msgid "Details"
 msgstr ""
 
+msgid "Ids"
+msgstr ""
+
 msgid "Synchronization Results"
 msgstr "Resultados de la sincronización"
 
@@ -676,6 +676,9 @@ msgstr "Estado"
 
 msgid "Summary"
 msgstr "Resumen"
+
+msgid "Import was successful"
+msgstr ""
 
 msgid "Messages"
 msgstr "Mensajes"
@@ -1112,3 +1115,6 @@ msgstr ""
 
 msgid "Settings saved"
 msgstr "Configuración guardada"
+
+#~ msgid "Imported"
+#~ msgstr "Importados"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2023-06-29T07:07:25.389Z\n"
+"POT-Creation-Date: 2024-03-08T12:55:49.199Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -664,9 +664,6 @@ msgstr "Base de données"
 msgid "Value for field '{{field}}' is invalid - {{value}}"
 msgstr ""
 
-msgid "Imported"
-msgstr "Importé"
-
 msgid "Updated"
 msgstr "Actualisé"
 
@@ -688,6 +685,9 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
+msgid "Ids"
+msgstr ""
+
 msgid "Synchronization Results"
 msgstr ""
 
@@ -695,6 +695,9 @@ msgid "Status"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "Import was successful"
 msgstr ""
 
 msgid "Messages"
@@ -1135,6 +1138,9 @@ msgstr ""
 
 msgid "Settings saved"
 msgstr "Paramètres sauvegardés"
+
+#~ msgid "Imported"
+#~ msgstr "Importé"
 
 #, fuzzy
 #~ msgid "Template Code"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2023-06-29T07:07:25.389Z\n"
+"POT-Creation-Date: 2024-03-08T12:55:49.199Z\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -699,9 +699,6 @@ msgstr "Data Set"
 msgid "Value for field '{{field}}' is invalid - {{value}}"
 msgstr ""
 
-msgid "Imported"
-msgstr "Importado"
-
 msgid "Updated"
 msgstr "Atualizada"
 
@@ -723,6 +720,9 @@ msgstr "Mensagem"
 msgid "Details"
 msgstr ""
 
+msgid "Ids"
+msgstr ""
+
 msgid "Synchronization Results"
 msgstr "Resultados da Sincronização"
 
@@ -731,6 +731,9 @@ msgstr "Estado"
 
 msgid "Summary"
 msgstr "Sumário"
+
+msgid "Import was successful"
+msgstr ""
 
 msgid "Messages"
 msgstr "Mensagens"
@@ -1169,6 +1172,9 @@ msgstr ""
 
 msgid "Settings saved"
 msgstr "Configurações salvas"
+
+#~ msgid "Imported"
+#~ msgstr "Importado"
 
 #, fuzzy
 #~ msgid "Template Code"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2023-06-29T07:07:25.389Z\n"
+"POT-Creation-Date: 2024-03-08T12:55:49.199Z\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgid "Data values - Create/update"
 msgstr "Значения данных - создание/обновление"
@@ -701,9 +701,6 @@ msgstr "Набор данных"
 msgid "Value for field '{{field}}' is invalid - {{value}}"
 msgstr ""
 
-msgid "Imported"
-msgstr "Импортировано"
-
 msgid "Updated"
 msgstr "Обновленный"
 
@@ -725,6 +722,9 @@ msgstr "Сообщение"
 msgid "Details"
 msgstr ""
 
+msgid "Ids"
+msgstr ""
+
 msgid "Synchronization Results"
 msgstr "Результаты синхронизации"
 
@@ -733,6 +733,9 @@ msgstr "Статус"
 
 msgid "Summary"
 msgstr "Резюме"
+
+msgid "Import was successful"
+msgstr ""
 
 msgid "Messages"
 msgstr "Сообщения"
@@ -1171,6 +1174,9 @@ msgstr "Нет захвата орг единицы соответствие э�
 
 msgid "Settings saved"
 msgstr "Сохранение настроек"
+
+#~ msgid "Imported"
+#~ msgstr "Импортировано"
 
 #, fuzzy
 #~ msgid "Template Code"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.3.3",
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
-        "@eyeseetea/d2-api": "1.13.2-beta.6",
+        "@eyeseetea/d2-api": "1.15.0",
         "@eyeseetea/d2-ui-components": "2.7.0-beta.3",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.12.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@dhis2/d2-ui-core": "7.3.3",
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
-        "@eyeseetea/d2-api": "1.11.0",
+        "@eyeseetea/d2-api": "1.13.2-beta.6",
         "@eyeseetea/d2-ui-components": "2.7.0-beta.3",
         "@eyeseetea/xlsx-populate": "4.1.0",
         "@material-ui/core": "4.12.3",

--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -6,11 +6,50 @@ import { postImport } from "./Dhis2Import";
 import i18n from "../locales";
 import { promiseMap } from "../utils/promises";
 import { TrackerPostResponse } from "@eyeseetea/d2-api/api/tracker";
+import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
+import { Geometry } from "../domain/entities/Geometry";
+import { D2Coordinates } from "@eyeseetea/d2-api/schemas";
+import { Id } from "../domain/entities/ReferenceObject";
+
+type EventToPost = Omit<D2TrackerEvent, "event"> & { event?: Id };
+
+const buildEventsPayload = (event: Event): EventToPost => {
+    return {
+        ...event,
+        dataValues: event.dataValues.map(dataValue => ({
+            dataElement: dataValue.dataElement,
+            value: dataValue.value.toString(),
+        })),
+        geometry: event.geometry ? transformGeometry(event.geometry) : null,
+    };
+};
+
+const transformGeometry = (geometry: Geometry): NonNullable<D2TrackerEvent["geometry"]> => {
+    switch (geometry.type) {
+        case "Point": {
+            return {
+                type: "Point",
+                coordinates: [geometry.coordinates.longitude, geometry.coordinates.latitude],
+            };
+        }
+        case "Polygon": {
+            const coordinates = geometry.coordinates.map((coordinates): D2Coordinates => {
+                return [coordinates.longitude, coordinates.latitude];
+            });
+            return {
+                type: "Polygon",
+                coordinates: [coordinates],
+            };
+        }
+    }
+};
 
 export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult[]> {
-    const eventsResult = await promiseMap(_.chunk(events, 200), eventsToSave => {
+    const eventsPayload = events.map(buildEventsPayload);
+
+    const eventsResult = await promiseMap(_.chunk(eventsPayload, 200), eventsToSave => {
         return postImport(
-            () => api.post<TrackerPostResponse>("/tracker?async=false", {}, { events: eventsToSave }).getData(),
+            () => api.post<TrackerPostResponse>("/tracker", { async: false }, { events: eventsToSave }).getData(),
             {
                 title: i18n.t("Data values - Create/update"),
                 model: i18n.t("Event"),

--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -2,17 +2,21 @@ import _ from "lodash";
 import { D2Api } from "../types/d2-api";
 import { Event } from "../domain/entities/DhisDataPackage";
 import { SynchronizationResult } from "../domain/entities/SynchronizationResult";
-import { ImportPostResponse, postImport } from "./Dhis2Import";
+import { postImport } from "./Dhis2Import";
 import i18n from "../locales";
 import { promiseMap } from "../utils/promises";
+import { TrackerPostResponse } from "@eyeseetea/d2-api/api/tracker";
 
 export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult[]> {
     const eventsResult = await promiseMap(_.chunk(events, 200), eventsToSave => {
-        return postImport(() => api.post<ImportPostResponse>("/events", {}, { events: eventsToSave }).getData(), {
-            title: i18n.t("Data values - Create/update"),
-            model: i18n.t("Event"),
-            splitStatsList: true,
-        });
+        return postImport(
+            () => api.post<TrackerPostResponse>("/tracker?async=false", {}, { events: eventsToSave }).getData(),
+            {
+                title: i18n.t("Data values - Create/update"),
+                model: i18n.t("Event"),
+                splitStatsList: true,
+            }
+        );
     });
     return eventsResult;
 }

--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -1,45 +1,7 @@
 import _ from "lodash";
-import {
-    SynchronizationResult,
-    SynchronizationStats,
-    SynchronizationStatus,
-} from "../domain/entities/SynchronizationResult";
+import { SynchronizationResult, SynchronizationStats } from "../domain/entities/SynchronizationResult";
 import i18n from "../locales";
 import { TrackerPostResponse } from "@eyeseetea/d2-api/api/tracker";
-
-type Status = "OK" | "ERROR";
-
-export interface ImportPostResponse {
-    status: Status;
-    message?: string;
-    response?: {
-        status: SynchronizationStatus;
-        imported: number;
-        updated: number;
-        deleted: number;
-        ignored: number;
-        total: number;
-        importSummaries?: Array<{
-            responseType: "ImportSummary";
-            description?: string;
-            status: SynchronizationStatus;
-            href?: string;
-            importCount: {
-                imported: number;
-                updated: number;
-                deleted: number;
-                ignored: number;
-            };
-            reference?: string;
-            conflicts?: {
-                object: string;
-                value: string;
-            }[];
-            // Only for TEI import
-            enrollments?: ImportPostResponse["response"];
-        }>;
-    };
-}
 
 export function processImportResponse(options: {
     title: string;
@@ -48,28 +10,20 @@ export function processImportResponse(options: {
     splitStatsList: boolean;
 }): SynchronizationResult {
     const { title, model, importResult, splitStatsList } = options;
-    const { message, bundleReport, status, stats } = importResult;
-
-    if (!bundleReport) return { title, status, message, rawResponse: importResult };
-
-    const objectReports = _.flatMap(bundleReport.typeReportMap, type => type.objectReports);
-
-    const errors = _.flatMap(objectReports, objectReport =>
-        objectReport.errorReports.map(errorReport => {
-            return {
-                id: objectReport.uid,
-                message: errorReport.message,
-                details: errorReport.errorCode,
-            };
-        })
-    );
+    const {
+        message,
+        bundleReport,
+        validationReport: { errorReports, warningReports },
+        status,
+        stats,
+    } = importResult;
 
     const fields = ["created", "updated", "ignored", "deleted", "total"] as const;
     const totalStats: SynchronizationStats = { type: "TOTAL", ..._.pick(stats, fields) };
 
-    const statsList = _(bundleReport.typeReportMap)
+    const statsList = _(bundleReport?.typeReportMap)
         .values()
-        .filter(({ stats }) => stats.total > 0)
+        .filter(typeReportMap => typeReportMap.stats.total > 0)
         .map(typeReportMap => {
             const typeIds = typeReportMap.objectReports.map(({ uid }) => uid);
             return {
@@ -84,7 +38,46 @@ export function processImportResponse(options: {
         ? _.compact([statsList.length === 1 ? null : totalStats, ...statsList])
         : [totalStats];
 
-    return { title, status, message, errors, stats: splitedStats, rawResponse: importResult };
+    const errors = errorReports.map(warningReport => {
+        return {
+            id: warningReport.uid,
+            message: warningReport.message,
+            details: warningReport.errorCode,
+        };
+    });
+
+    const warnings = warningReports.map(warningReport => {
+        return {
+            id: warningReport.uid,
+            message: warningReport.message,
+            details: warningReport.errorCode,
+        };
+    });
+
+    if (!bundleReport) return { title, status, stats: splitedStats, errors, message, rawResponse: importResult };
+
+    const objectReports = _.flatMap(bundleReport.typeReportMap, type => type.objectReports);
+
+    const objectReportErrors = _.flatMap(objectReports, objectReport =>
+        objectReport.errorReports.map(errorReport => {
+            return {
+                id: objectReport.uid,
+                message: errorReport.message,
+                details: errorReport.errorCode,
+            };
+        })
+    );
+
+    return {
+        title,
+        status,
+        message,
+        errors,
+        warnings,
+        objectReportErrors,
+        stats: splitedStats,
+        rawResponse: importResult,
+    };
 }
 
 export async function postImport(

--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -70,7 +70,6 @@ export function processImportResponse(options: {
     const statsList = _(bundleReport.typeReportMap)
         .values()
         .filter(({ stats }) => stats.total > 0)
-        //.flatMap(({ objectReports }) => objectReports)
         .map(typeReportMap => {
             const typeIds = typeReportMap.objectReports.map(({ uid }) => uid);
             return {

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -302,6 +302,9 @@ async function getConstraintForTypeProgram(
                 orgUnit: orgUnit.id,
                 startDate: startDate ? moment(startDate).format("YYYY-MM-DD") : undefined,
                 endDate: endDate ? moment(endDate).format("YYYY-MM-DD") : undefined,
+                fields: {
+                    $all: true,
+                },
             })
             .getData();
 

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -339,10 +339,10 @@ async function getApiEvents(
 
             return {
                 event: data.id,
-                trackedEntityInstance: teiId,
+                trackedEntity: teiId,
                 program: program,
                 orgUnit: data.orgUnit,
-                eventDate: data.period,
+                occurredAt: data.period,
                 attributeOptionCombo: data.attribute,
                 status: "COMPLETED" as const,
                 programStage: data.programStage,

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -245,6 +245,75 @@ async function uploadTeis(options: {
                 return {
                     status: result?.status === "SUCCESS" ? "OK" : "ERROR",
                     response: result ?? undefined,
+                    bundleReport: {
+                        typeReportMap: {
+                            ENROLLMENT: {
+                                objectReports: [],
+                                stats: {
+                                    created: result?.imported || 0,
+                                    updated: result?.updated || 0,
+                                    ignored: result?.ignored || 0,
+                                    deleted: result?.deleted || 0,
+                                    total: result?.total || 0,
+                                },
+                                trackerType: "ENROLLMENT",
+                            },
+                            EVENT: {
+                                objectReports: [],
+                                stats: {
+                                    created: result?.imported || 0,
+                                    updated: result?.updated || 0,
+                                    ignored: result?.ignored || 0,
+                                    deleted: result?.deleted || 0,
+                                    total: result?.total || 0,
+                                },
+                                trackerType: "EVENT",
+                            },
+                            RELATIONSHIP: {
+                                objectReports: [],
+                                stats: {
+                                    created: result?.imported || 0,
+                                    updated: result?.updated || 0,
+                                    ignored: result?.ignored || 0,
+                                    deleted: result?.deleted || 0,
+                                    total: result?.total || 0,
+                                },
+                                trackerType: "RELATIONSHIP",
+                            },
+                            TRACKED_ENTITY: {
+                                objectReports: [],
+                                stats: {
+                                    created: result?.imported || 0,
+                                    updated: result?.updated || 0,
+                                    ignored: result?.ignored || 0,
+                                    deleted: result?.deleted || 0,
+                                    total: result?.total || 0,
+                                },
+                                trackerType: "TRACKED_ENTITY",
+                            },
+                        },
+                        stats: {
+                            created: result?.imported || 0,
+                            updated: result?.updated || 0,
+                            ignored: result?.ignored || 0,
+                            deleted: result?.deleted || 0,
+                            total: result?.total || 0,
+                        },
+                        status: "OK",
+                    },
+                    message: "",
+                    stats: {
+                        created: result?.imported || 0,
+                        updated: result?.updated || 0,
+                        ignored: result?.ignored || 0,
+                        deleted: result?.deleted || 0,
+                        total: result?.total || 0,
+                    },
+                    validationReport: {
+                        errorReports: [],
+                        warningReports: [],
+                    },
+                    timingsStats: [],
                 };
             },
             {

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -505,8 +505,8 @@ export class InstanceDhisRepository implements InstanceRepository {
                     pageSize: 250,
                     attributeCc: categoryComboId,
                     attributeCos: categoryOptionId,
-                    startDate: startDate?.format("YYYY-MM-DD"),
-                    endDate: endDate?.format("YYYY-MM-DD"),
+                    occurredAfter: startDate?.format("YYYY-MM-DD"),
+                    occurredBefore: endDate?.format("YYYY-MM-DD"),
                     cache: Math.random(),
                     // @ts-ignore FIXME: Add property in d2-api
                     fields: "*",

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -47,7 +47,7 @@ export interface TrackedEntityType {
     featureType: TrackedEntityTypeFeatureType;
 }
 
-export type TrackedEntityTypeFeatureType = "none" | "point" | "polygon";
+export type TrackedEntityTypeFeatureType = "none" | "Point" | "Polygon";
 
 export interface DataElement {
     id: Id;

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -28,10 +28,11 @@ export interface DataPackageData {
     attribute?: Id;
     trackedEntityInstance?: Id;
     programStage?: Id;
-    coordinate?: {
-        latitude: string;
-        longitude: string;
-    };
+    geometry?: {
+        type: string;
+        coordinates: [string, string];
+    } | null;
+    coordinate?: { latitude: string; longitude: string };
     dataValues: DataPackageDataValue[];
 }
 

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -1,6 +1,6 @@
 import { DataFormType } from "./DataForm";
 import { Id } from "./ReferenceObject";
-import { TrackedEntityInstance } from "./TrackedEntityInstance";
+import { TrackedEntity } from "./TrackedEntityInstance";
 
 export type DataPackage = GenericProgramPackage | TrackerProgramPackage;
 export type DataPackageValue = string | number | boolean;
@@ -16,7 +16,7 @@ export interface GenericProgramPackage extends BaseDataPackage {
 
 export interface TrackerProgramPackage extends BaseDataPackage {
     type: "trackerPrograms";
-    trackedEntityInstances: TrackedEntityInstance[];
+    trackedEntities: TrackedEntity[];
 }
 
 export interface DataPackageData {
@@ -28,10 +28,6 @@ export interface DataPackageData {
     attribute?: Id;
     trackedEntityInstance?: Id;
     programStage?: Id;
-    geometry?: {
-        type: string;
-        coordinates: [string, string];
-    } | null;
     coordinate?: { latitude: string; longitude: string };
     dataValues: DataPackageDataValue[];
 }

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -1,4 +1,4 @@
-import { D2Geometry } from "@eyeseetea/d2-api";
+import { Geometry } from "./Geometry";
 
 export interface EventsPackage {
     events: Event[];
@@ -22,23 +22,19 @@ export interface Event {
     event?: string;
     orgUnit: string;
     program: string;
-    status: string;
+    status: EventStatus;
     occurredAt: string;
-    geometry?: {
-        type: string;
-        coordinates: [string, string];
-    } | null;
-    coordinate?: {
-        latitude: string;
-        longitude: string;
-    };
+    geometry?: Geometry;
     attributeOptionCombo?: string;
     trackedEntity?: string;
     programStage?: string;
     dataValues: EventDataValue[];
+    enrollment?: string;
 }
 
 export interface EventDataValue {
     dataElement: string;
     value: string | number | boolean;
 }
+
+type EventStatus = "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -1,3 +1,5 @@
+import { D2Geometry } from "@eyeseetea/d2-api";
+
 export interface EventsPackage {
     events: Event[];
 }
@@ -21,13 +23,10 @@ export interface Event {
     orgUnit: string;
     program: string;
     status: string;
-    eventDate: string;
-    coordinate?: {
-        latitude: string;
-        longitude: string;
-    };
+    occurredAt: string;
+    geometry?: D2Geometry;
     attributeOptionCombo?: string;
-    trackedEntityInstance?: string;
+    trackedEntity?: string;
     programStage?: string;
     dataValues: EventDataValue[];
 }

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -24,7 +24,14 @@ export interface Event {
     program: string;
     status: string;
     occurredAt: string;
-    geometry?: D2Geometry;
+    geometry?: {
+        type: string;
+        coordinates: [string, string];
+    } | null;
+    coordinate?: {
+        latitude: string;
+        longitude: string;
+    };
     attributeOptionCombo?: string;
     trackedEntity?: string;
     programStage?: string;

--- a/src/domain/entities/Geometry.ts
+++ b/src/domain/entities/Geometry.ts
@@ -3,49 +3,49 @@ import { TrackedEntityType } from "./DataForm";
 
 export type Coordinates = { latitude: number; longitude: number };
 
-export type Geometry =
-    | { type: "none" }
-    | { type: "point"; coordinates: Coordinates }
-    | { type: "polygon"; coordinatesList: Coordinates[] };
+export type Geometry = { type: "Point"; coordinates: Coordinates } | { type: "Polygon"; coordinates: Coordinates[] };
 
-export function getGeometryAsString(geometry: Geometry): string {
+export function getGeometryAsString(geometry: Geometry | undefined): string {
+    if (!geometry) return "";
     switch (geometry.type) {
-        case "none":
-            return "";
-        case "point": {
+        case "Point": {
             const { longitude, latitude } = geometry.coordinates;
             return `[${longitude}, ${latitude}]`;
         }
-        case "polygon": {
-            const items = geometry.coordinatesList.map(
-                coordinates => `[${coordinates.longitude}, ${coordinates.latitude}]`
-            );
+        case "Polygon": {
+            const items = geometry.coordinates.map(coordinates => `[${coordinates.latitude}, ${coordinates.latitude}]`);
             return `[${items.join(", ")}]`;
+        }
+        default: {
+            return "";
         }
     }
 }
 
-export function getGeometryFromString(trackedEntityType: Maybe<TrackedEntityType>, value: string): Geometry {
+export function getGeometryFromString(
+    trackedEntityType: Maybe<TrackedEntityType>,
+    value: string
+): Geometry | undefined {
     if (!trackedEntityType) {
         console.error(`Expected tracked entity type on dataForm`);
-        return { type: "none" };
+        return undefined;
     }
     const cleanValue = value.trim().replace(/\s*/g, "");
-    if (!cleanValue) return { type: "none" };
+    if (!cleanValue) return undefined;
 
     switch (trackedEntityType.featureType) {
         case "none":
-            return { type: "none" };
-        case "point":
-            return { type: "point", coordinates: getCoordinatesFromString(cleanValue) };
-        case "polygon": {
+            return undefined;
+        case "Point":
+            return { type: "Point", coordinates: getCoordinatesFromString(cleanValue) };
+        case "Polygon": {
             const match = cleanValue.match(/^\[(.+)\]/);
             if (!match) throw new Error(`Invalid format for polygon: ${cleanValue}`);
             // Perform split "[[lon1,lat1], [lat2,lon2]]"" -> ["[lon1,lat1]", "[lon1,lat1]"]
             // Re-add the trailing "]" that got eaten by the split for each pair.
             const items = (match[1] || "").split(/\]\s*,/).map(pairS => (!pairS.endsWith("]") ? pairS + "]" : pairS));
             const coordinatesList = items.map(getCoordinatesFromString);
-            return { type: "polygon", coordinatesList };
+            return { type: "Polygon", coordinates: coordinatesList };
         }
     }
 }

--- a/src/domain/entities/SynchronizationResult.ts
+++ b/src/domain/entities/SynchronizationResult.ts
@@ -1,12 +1,13 @@
-export type SynchronizationStatus = "PENDING" | "SUCCESS" | "WARNING" | "ERROR" | "NETWORK ERROR";
+export type SynchronizationStatus = "PENDING" | "SUCCESS" | "OK" | "WARNING" | "ERROR" | "NETWORK ERROR";
 
 export interface SynchronizationStats {
     type?: string;
-    imported: number;
+    created: number;
     updated: number;
     ignored: number;
     deleted: number;
     total?: number;
+    ids?: string[];
 }
 
 export interface ErrorMessage {

--- a/src/domain/entities/SynchronizationResult.ts
+++ b/src/domain/entities/SynchronizationResult.ts
@@ -22,5 +22,7 @@ export interface SynchronizationResult {
     message?: string;
     stats?: SynchronizationStats[];
     errors?: ErrorMessage[];
+    warnings?: ErrorMessage[];
+    objectReportErrors?: ErrorMessage[];
     rawResponse: object;
 }

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -138,8 +138,8 @@ interface BaseDataSource {
     attribute?: SheetRef | ValueRef;
     eventId?: SheetRef | ValueRef;
     coordinates?: {
-        latitude: SheetRef | ValueRef;
-        longitude: SheetRef | ValueRef;
+        latitude: ColumnRef | CellRef | ValueRef;
+        longitude: ColumnRef | CellRef | ValueRef;
     };
 }
 
@@ -247,6 +247,8 @@ export function setDataEntrySheet(dataSource: RowDataSource, sheets: SheetE[]): 
         get(dataSource.categoryOption),
         get(dataSource.attribute),
         get(dataSource.eventId),
+        get(dataSource.coordinates?.latitude),
+        get(dataSource.coordinates?.longitude),
     ]);
 
     const sheetsFromDataSource = _.uniq(sheetsFromDataSourceAll);
@@ -281,6 +283,13 @@ export function setDataEntrySheet(dataSource: RowDataSource, sheets: SheetE[]): 
             categoryOption: set(dataSource.categoryOption),
             attribute: set(dataSource.attribute),
             eventId: set(dataSource.eventId),
+            ...(dataSource.coordinates?.latitude &&
+                dataSource.coordinates?.longitude && {
+                    coordinates: {
+                        latitude: set(dataSource.coordinates.latitude),
+                        longitude: set(dataSource.coordinates.longitude),
+                    },
+                }),
         };
     });
 }

--- a/src/domain/entities/TrackedEntityInstance.ts
+++ b/src/domain/entities/TrackedEntityInstance.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
 import { DataElementType } from "./DataForm";
-import { Geometry } from "./Geometry";
 import { Id, Ref } from "./ReferenceObject";
 import { Relationship } from "./Relationship";
+import { Geometry } from "./Geometry";
 
-export interface TrackedEntityInstance {
+export interface TrackedEntity {
     program: Ref;
     id: Id;
     orgUnit: Ref;
@@ -12,13 +12,13 @@ export interface TrackedEntityInstance {
     attributeValues: AttributeValue[];
     enrollment: Enrollment | undefined;
     relationships: Relationship[];
-    geometry: Geometry;
+    geometry: Geometry | undefined;
 }
 
 export interface Enrollment {
     id?: Id;
-    enrollmentDate: string;
-    incidentDate: string;
+    enrolledAt: string;
+    occurredAt?: string;
 }
 
 export interface AttributeValue {
@@ -39,9 +39,9 @@ export interface Attribute {
     optionSet?: { id: Id; options: Array<{ id: string; code: string }> };
 }
 
-export function getRelationships(trackedEntityInstances: TrackedEntityInstance[]): Relationship[] {
-    return _(trackedEntityInstances)
-        .flatMap(tei => tei.relationships)
+export function getRelationships(trackedEntities: TrackedEntity[]): Relationship[] {
+    return _(trackedEntities)
+        .flatMap(trackedEntity => trackedEntity.relationships)
         .uniqWith(_.isEqual)
         .value();
 }

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -351,7 +351,7 @@ export class ExcelBuilder {
     private async fillRows(template: Template, dataSource: RowDataSource, payload: DataPackage) {
         let { rowStart } = dataSource.range;
 
-        for (const { id, orgUnit, period, attribute, dataValues } of payload.dataEntries) {
+        for (const { id, orgUnit, period, attribute, dataValues, geometry } of payload.dataEntries) {
             const cells = await this.excelRepository.getCellsInRange(template.id, {
                 ...dataSource.range,
                 rowStart,
@@ -374,6 +374,17 @@ export class ExcelBuilder {
             const attributeCell = await this.findRelative(template, dataSource.attribute, cells[0]);
             if (attributeCell && attribute) {
                 await this.excelRepository.writeCell(template.id, attributeCell, attribute);
+            }
+
+            const latitudeCell = await this.findRelative(template, dataSource.coordinates?.latitude, cells[0]);
+            const latitude = geometry?.coordinates?.[0];
+            if (latitudeCell && latitude) {
+                await this.excelRepository.writeCell(template.id, latitudeCell, latitude);
+            }
+            const longitudeCell = await this.findRelative(template, dataSource.coordinates?.longitude, cells[0]);
+            const longitude = geometry?.coordinates?.[1];
+            if (longitudeCell && longitude) {
+                await this.excelRepository.writeCell(template.id, longitudeCell, longitude);
             }
 
             for (const cell of cells) {

--- a/src/domain/repositories/InstanceRepository.ts
+++ b/src/domain/repositories/InstanceRepository.ts
@@ -8,7 +8,7 @@ import { Locale } from "../entities/Locale";
 import { OrgUnit } from "../entities/OrgUnit";
 import { Id, NamedRef } from "../entities/ReferenceObject";
 import { SynchronizationResult } from "../entities/SynchronizationResult";
-import { Program, TrackedEntityInstance } from "../entities/TrackedEntityInstance";
+import { Program, TrackedEntity } from "../entities/TrackedEntityInstance";
 
 export interface GetDataPackageParams {
     type: DataFormType;
@@ -40,7 +40,7 @@ export interface InstanceRepository {
     importDataPackage(dataPackage: DataPackage): Promise<SynchronizationResult[]>;
     getProgram(programId: Id): Promise<Program | undefined>;
     convertDataPackage(dataPackage: DataPackage): EventsPackage | AggregatedPackage;
-    getBuilderMetadata(teis: TrackedEntityInstance[]): Promise<BuilderMetadata>;
+    getBuilderMetadata(teis: TrackedEntity[]): Promise<BuilderMetadata>;
 }
 
 export interface BuilderMetadata {

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -18,7 +18,7 @@ import { TemplateRepository } from "../repositories/TemplateRepository";
 import { FileRepository } from "../repositories/FileRepository";
 import { FileResource } from "../entities/FileResource";
 import { ImportSourceRepository } from "../repositories/ImportSourceRepository";
-import { TrackedEntityInstance } from "../entities/TrackedEntityInstance";
+import { TrackedEntity } from "../entities/TrackedEntityInstance";
 import { Maybe } from "../../types/utils";
 
 export type ImportTemplateError =
@@ -272,33 +272,28 @@ export class ImportTemplateUseCase implements UseCase {
                       );
                   });
 
-        const trackedEntityInstances = getTrackedEntityInstances(
-            excelDataPackage,
-            useBuilderOrgUnits,
-            selectedOrgUnits
-        );
+        const trackedEntities = getTrackedEntities(excelDataPackage, useBuilderOrgUnits, selectedOrgUnits);
 
         return {
             dataValues: {
                 type: dataForm.type,
                 dataEntries: files.length === 0 ? excelFile : this.addImagesToDataEntries(files, excelFile, dataForm),
-                trackedEntityInstances:
-                    files.length === 0 ? trackedEntityInstances : this.addImagesToTeis(files, trackedEntityInstances),
+                trackedEntities: files.length === 0 ? trackedEntities : this.addImagesToTeis(files, trackedEntities),
             },
             invalidDataValues: {
                 type: dataForm.type,
                 dataEntries: invalidDataValues,
-                trackedEntityInstances: [],
+                trackedEntities: [],
             },
             existingDataValues: {
                 type: dataForm.type,
                 dataEntries: existingDataValues,
-                trackedEntityInstances: [],
+                trackedEntities: [],
             },
             instanceDataValues: {
                 type: dataForm.type,
                 dataEntries: instanceDataValues,
-                trackedEntityInstances: [],
+                trackedEntities: [],
             },
         };
     }
@@ -324,7 +319,7 @@ export class ImportTemplateUseCase implements UseCase {
         });
     }
 
-    private addImagesToTeis(files: FileResource[], trackedEntityInstances: TrackedEntityInstance[]) {
+    private addImagesToTeis(files: FileResource[], trackedEntityInstances: TrackedEntity[]) {
         return trackedEntityInstances.map(tei => {
             return {
                 ...tei,
@@ -444,13 +439,9 @@ export class ImportTemplateUseCase implements UseCase {
     }
 }
 
-function getTrackedEntityInstances(
-    excelDataValues: DataPackage,
-    useBuilderOrgUnits: boolean,
-    selectedOrgUnitPaths: string[]
-) {
+function getTrackedEntities(excelDataValues: DataPackage, useBuilderOrgUnits: boolean, selectedOrgUnitPaths: string[]) {
     const orgUnitOverridePath = useBuilderOrgUnits ? selectedOrgUnitPaths[0] : null;
-    const teis = excelDataValues.type === "trackerPrograms" ? excelDataValues.trackedEntityInstances : [];
+    const teis = excelDataValues.type === "trackerPrograms" ? excelDataValues.trackedEntities : [];
 
     return orgUnitOverridePath
         ? teis.map(tei => ({ ...tei, orgUnit: { id: cleanOrgUnitPath(orgUnitOverridePath) } }))

--- a/src/webapp/components/sync-summary/SyncSummary.tsx
+++ b/src/webapp/components/sync-summary/SyncSummary.tsx
@@ -72,7 +72,7 @@ const buildSummaryTable = (stats: SynchronizationStats[]) => {
                 </TableRow>
             </TableHead>
             <TableBody>
-                {stats.map(({ type, created, updated, deleted, ignored, total, ids }, i) => (
+                {stats.map(({ type, created, updated, deleted, ignored, total }, i) => (
                     <TableRow key={`row-${i}`}>
                         <TableCell>{type}</TableCell>
                         <TableCell>{created}</TableCell>

--- a/src/webapp/components/sync-summary/SyncSummary.tsx
+++ b/src/webapp/components/sync-summary/SyncSummary.tsx
@@ -161,7 +161,7 @@ const SyncSummary = ({ results, onClose }: SyncSummaryProps) => {
             fullWidth={true}
         >
             <DialogContent>
-                {results.map(({ title, status, stats = [], message, errors }, idx) => (
+                {results.map(({ title, status, stats = [], message, errors, warnings, objectReportErrors }, idx) => (
                     <Accordion defaultExpanded={results.length === 1} className={classes.accordion} key={`row-${idx}`}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             <Typography className={classes.accordionHeading1}>
@@ -186,23 +186,67 @@ const SyncSummary = ({ results, onClose }: SyncSummaryProps) => {
 
                         {!_.isEmpty(stats) && (
                             <>
-                                <AccordionDetails className={classes.accordionDetails}>
-                                    {buildSummaryTable([...stats])}
-                                </AccordionDetails>
+                                <>
+                                    <AccordionDetails
+                                        className={classes.accordionDetails}
+                                        style={{ paddingTop: "15px" }}
+                                    >
+                                        <Typography variant="overline">{i18n.t("Stats")}</Typography>
+                                    </AccordionDetails>
+                                    <AccordionDetails className={classes.accordionDetails}>
+                                        {buildSummaryTable([...stats])}
+                                    </AccordionDetails>
+                                </>
 
-                                <AccordionDetails className={classes.accordionDetails}>
-                                    {buildTypeIdsTable([...stats])}
-                                </AccordionDetails>
+                                {stats.some(stat => stat.ids) && (
+                                    <>
+                                        <AccordionDetails
+                                            className={classes.accordionDetails}
+                                            style={{ paddingTop: "15px" }}
+                                        >
+                                            <Typography variant="overline">{i18n.t("Modified Data")}</Typography>
+                                        </AccordionDetails>
+                                        <AccordionDetails className={classes.accordionDetails}>
+                                            {buildTypeIdsTable([...stats])}
+                                        </AccordionDetails>
+                                    </>
+                                )}
                             </>
                         )}
 
                         {errors && errors.length > 0 && (
                             <div>
+                                <Accordion defaultExpanded={true} className={classes.accordion}>
+                                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                        <Typography variant="overline">{i18n.t("Error Messages")}</Typography>
+                                    </AccordionSummary>
+                                    <AccordionDetails className={classes.accordionDetails}>
+                                        {buildMessageTable(_.take(errors, 10))}
+                                    </AccordionDetails>
+                                </Accordion>
+                            </div>
+                        )}
+
+                        {warnings && warnings.length > 0 && (
+                            <div>
+                                <Accordion defaultExpanded={true} className={classes.accordion}>
+                                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                        <Typography variant="overline">{i18n.t("Warnings")}</Typography>
+                                    </AccordionSummary>
+                                    <AccordionDetails className={classes.accordionDetails}>
+                                        {buildMessageTable(_.take(warnings, 10))}
+                                    </AccordionDetails>
+                                </Accordion>
+                            </div>
+                        )}
+
+                        {objectReportErrors && objectReportErrors.length > 0 && (
+                            <div>
                                 <AccordionDetails className={classes.accordionDetails}>
                                     <Typography variant="overline">{i18n.t("Messages")}</Typography>
                                 </AccordionDetails>
                                 <AccordionDetails className={classes.accordionDetails}>
-                                    {buildMessageTable(_.take(errors, 10))}
+                                    {buildMessageTable(_.take(objectReportErrors, 10))}
                                 </AccordionDetails>
                             </div>
                         )}

--- a/src/webapp/components/sync-summary/SyncSummary.tsx
+++ b/src/webapp/components/sync-summary/SyncSummary.tsx
@@ -64,7 +64,7 @@ const buildSummaryTable = (stats: SynchronizationStats[]) => {
             <TableHead>
                 <TableRow>
                     <TableCell>{i18n.t("Type")}</TableCell>
-                    <TableCell>{i18n.t("Imported")}</TableCell>
+                    <TableCell>{i18n.t("Created")}</TableCell>
                     <TableCell>{i18n.t("Updated")}</TableCell>
                     <TableCell>{i18n.t("Deleted")}</TableCell>
                     <TableCell>{i18n.t("Ignored")}</TableCell>
@@ -72,14 +72,14 @@ const buildSummaryTable = (stats: SynchronizationStats[]) => {
                 </TableRow>
             </TableHead>
             <TableBody>
-                {stats.map(({ type, imported, updated, deleted, ignored, total }, i) => (
+                {stats.map(({ type, created, updated, deleted, ignored, total, ids }, i) => (
                     <TableRow key={`row-${i}`}>
                         <TableCell>{type}</TableCell>
-                        <TableCell>{imported}</TableCell>
+                        <TableCell>{created}</TableCell>
                         <TableCell>{updated}</TableCell>
                         <TableCell>{deleted}</TableCell>
                         <TableCell>{ignored}</TableCell>
-                        <TableCell>{total || _.sum([imported, deleted, ignored, updated])}</TableCell>
+                        <TableCell>{total || _.sum([created, deleted, ignored, updated])}</TableCell>
                     </TableRow>
                 ))}
             </TableBody>
@@ -103,6 +103,27 @@ const buildMessageTable = (messages: ErrorMessage[]) => {
                         <TableCell>{id}</TableCell>
                         <TableCell>{message}</TableCell>
                         <TableCell>{details}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+};
+
+const buildTypeIdsTable = (stats: SynchronizationStats[]) => {
+    return (
+        <Table>
+            <TableHead>
+                <TableRow>
+                    <TableCell>{i18n.t("Type")}</TableCell>
+                    <TableCell>{i18n.t("Ids")}</TableCell>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {stats.map(({ type, ids }, i) => (
+                    <TableRow key={`row-${i}`}>
+                        <TableCell>{type}</TableCell>
+                        <TableCell>{ids?.join(", ")}</TableCell>
                     </TableRow>
                 ))}
             </TableBody>
@@ -157,16 +178,22 @@ const SyncSummary = ({ results, onClose }: SyncSummaryProps) => {
                             <Typography variant="overline">{i18n.t("Summary")}</Typography>
                         </AccordionDetails>
 
-                        {message && (
+                        {(message || status === "OK") && (
                             <AccordionDetails className={classes.accordionDetails}>
-                                <Typography variant="body2">{message}</Typography>
+                                <Typography variant="body2">{message || i18n.t("Import was successful")}</Typography>
                             </AccordionDetails>
                         )}
 
                         {!_.isEmpty(stats) && (
-                            <AccordionDetails className={classes.accordionDetails}>
-                                {buildSummaryTable([...stats])}
-                            </AccordionDetails>
+                            <>
+                                <AccordionDetails className={classes.accordionDetails}>
+                                    {buildSummaryTable([...stats])}
+                                </AccordionDetails>
+
+                                <AccordionDetails className={classes.accordionDetails}>
+                                    {buildTypeIdsTable([...stats])}
+                                </AccordionDetails>
+                            </>
                         )}
 
                         {errors && errors.length > 0 && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.13.2-beta.6":
-  version "1.13.2-beta.6"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.13.2-beta.6.tgz#e21c89f9e132bf8670a7b197b999ed25b89e2192"
-  integrity sha512-HPT5Q0+muLKBwlC6h5NwG/agQMWMcSxiN5uSVWCee42TfDf7o7bYAU78ly+1TE7kl2f7HBoYfdPVf7oKQ3kWUA==
+"@eyeseetea/d2-api@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.15.0.tgz#d10d33b6a062b4636324224b943f68eb466ecd3a"
+  integrity sha512-9NGJBkk0vagneJsRN6x1jsNSAG4mhNa5Wh3PlylBsqitgj6vS1/49Uddk+pkvegsdwgMqqcetGKOQea3JYd3Ig==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"
@@ -3976,6 +3976,7 @@
     d2 "^31.8.1"
     dotenv "^8.0.0"
     express "^4.17.1"
+    form-data "^4.0.0"
     iconv-lite "0.6.2"
     isomorphic-fetch "3.0.0"
     lodash "^4.17.15"
@@ -3983,6 +3984,7 @@
     node-schedule "^1.3.2"
     qs "^6.9.0"
     react "^16.12.0"
+    side-channel "^1.0.4"
     yargs "^14.0.0"
 
 "@eyeseetea/d2-ui-components@2.7.0-beta.3":
@@ -10170,6 +10172,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.11.0.tgz#dc76fe0c0f00cc844b0326d740c03c15428fc362"
-  integrity sha512-zNIatB/MqKoSgrsOgIbDygIAKs0D1kEzHNxVA59+QqFOPXZ5l1p7GBrgjz8e/JkS/7KrvZWEnSqDku/o7eLRxg==
+"@eyeseetea/d2-api@1.13.2-beta.6":
+  version "1.13.2-beta.6"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.13.2-beta.6.tgz#e21c89f9e132bf8670a7b197b999ed25b89e2192"
+  integrity sha512-HPT5Q0+muLKBwlC6h5NwG/agQMWMcSxiN5uSVWCee42TfDf7o7bYAU78ly+1TE7kl2f7HBoYfdPVf7oKQ3kWUA==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"


### PR DESCRIPTION
### :pushpin: References 

* **Issue:** Closes #86943uvdu https://app.clickup.com/t/86943uvdu & https://app.clickup.com/t/8693r9fek
* **d2-api**: Requires  https://github.com/EyeSeeTea/d2-api/pull/146

### :memo: Implementation

- Fix the geometry read/write from excel, and use the new tracker endpoint (import with geography only works with the new endpoint)
- Use the new tracker endpoint for both Event & TrackedEntities, in order to uniformize the calls & use the same response to show the validation reports, summary, errors, and warnings (new).

### :fire: Notes for the reviewer
- The new endpoint requires the events to have an enrollment value, that wasn't needed in the past in order to POST events. I've added the enrollment based on the trackedEntity's enrollmentId coming from the excel, or a new one is created. Not sure if this the optimal behaviour or if it should be fetched, but I leave it as a comment. This is on Dhis2TrackedEntities -> getApiEvents()

Files used for testing:
[AMC - Product Register.xlsx](https://github.com/EyeSeeTea/Bulk-Load/files/15004383/AMC.-.Product.Register.xlsx)
[COVID-19 Health facility information.xlsx](https://github.com/EyeSeeTea/Bulk-Load/files/15004385/COVID-19.Health.facility.information.xlsx)


### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others
