### PR TITLE
Feat: redesign download template page filter order

### DIFF
--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -288,19 +288,10 @@ export const TemplateSelector = ({
     const selected = state.id && state.templateId ? getOptionValue({ id: state.id, templateId: state.templateId }) : "";
 
     return (
-        <React.Fragment>
+        <>
             <h3 className={classes.title}>{i18n.t("Template")}</h3>
 
             <div className={classes.row}>
-                <div className={classes.select}>
-                    <Select
-                        placeholder={i18n.t("Select template to export...")}
-                        onChange={onTemplateChange}
-                        options={templates}
-                        value={selected}
-                    />
-                </div>
-
                 {models.length > 1 && (
                     <div className={classes.select}>
                         <Select
@@ -311,6 +302,14 @@ export const TemplateSelector = ({
                         />
                     </div>
                 )}
+                <div className={classes.select}>
+                    <Select
+                        placeholder={i18n.t("Select template to export...")}
+                        onChange={onTemplateChange}
+                        options={templates}
+                        value={selected}
+                    />
+                </div>
             </div>
 
             {state.type === "dataSets" && state.templateType === "custom" && showPopulate && (
@@ -356,7 +355,7 @@ export const TemplateSelector = ({
             )}
 
             {settings.orgUnitSelection !== "import" && showPopulate && (
-                <React.Fragment>
+                <>
                     <h3>{i18n.t("Organisation units")}</h3>
 
                     <div>
@@ -399,7 +398,7 @@ export const TemplateSelector = ({
                                 {i18n.t("User does not have any capture organisations units")}
                             </div>
                         ))}
-                </React.Fragment>
+                </>
             )}
 
             {state.templateType !== "custom" && <h3>{i18n.t("Advanced template properties")}</h3>}
@@ -567,7 +566,7 @@ export const TemplateSelector = ({
                     />
                 </div>
             )}
-        </React.Fragment>
+        </>
     );
 };
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Part one of [Redesign download template page](https://app.clickup.com/t/8694wfy5f)
- CU-8694wfy5f

### :memo: Implementation

Exchange filters position at Template Download Page, keeping expected functionality.

### :fire: Notes for the reviewer

### :art: Screenshots
<img width="1033" alt="Captura de pantalla 2024-06-25 a las 14 27 51" src="https://github.com/WISCENTD-UPC/Bulk-Load/assets/55712984/6e83c685-f9b2-4b8d-8cde-0b0711092cee">

After selecting only one Data Model on configuration we keep the expected outcome:
<img width="603" alt="Captura de pantalla 2024-06-25 a las 14 14 15" src="https://github.com/WISCENTD-UPC/Bulk-Load/assets/55712984/2bc4d5c4-f406-4c9c-bb12-79711e8d5824">
<img width="447" alt="Captura de pantalla 2024-06-25 a las 14 14 30" src="https://github.com/WISCENTD-UPC/Bulk-Load/assets/55712984/eeb1508d-3cae-4ca8-9105-f49167f8ef08">

<img width="1039" alt="Captura de pantalla 2024-06-25 a las 14 14 07" src="https://github.com/WISCENTD-UPC/Bulk-Load/assets/55712984/1d14995f-63d5-4ad7-b0e6-93caf5f4531d">
