### PR TITLE
remove write permission for program stage generation

### DIFF
--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -1029,7 +1029,7 @@ export class SheetBuilder {
         const { element } = this.builder;
 
         return _(element.programStages)
-            .filter(({ access }) => access?.read && access?.data?.read && access?.data?.write)
+            .filter(({ access }) => access?.read && access?.data?.read)
             .value();
     }
 

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -86,7 +86,9 @@ export class SheetBuilder {
             instancesSheet = workbook.addWorksheet(teiSheetName);
 
             // ProgramStage sheets
-            const programStages = this.getProgramStages().map(programStageT => metadata.get(programStageT.id));
+            const programStages = this.getProgramStagesWithReadPermission().map(programStageT =>
+                metadata.get(programStageT.id)
+            );
 
             withSheetNames(programStages).forEach((programStage: any) => {
                 const sheet = workbook.addWorksheet(programStage.sheetName);
@@ -190,7 +192,9 @@ export class SheetBuilder {
     private fillProgramStageSheets(programStageSheets: Record<Id, Sheet>) {
         const { elementMetadata: metadata, element: program, settings } = this.builder;
 
-        const programStages = this.getProgramStages().map(programStageT => metadata.get(programStageT.id));
+        const programStages = this.getProgramStagesWithReadPermission().map(programStageT =>
+            metadata.get(programStageT.id)
+        );
         const sheets = withSheetNames(programStages);
 
         _.forEach(programStageSheets, (sheet, programStageId) => {
@@ -917,7 +921,7 @@ export class SheetBuilder {
                 groupId++;
             });
         } else {
-            _.forEach(this.getProgramStages(), programStageT => {
+            _.forEach(this.getProgramStagesWithReadPermission(), programStageT => {
                 const programStage = metadata.get(programStageT.id);
 
                 this.createColumn(
@@ -1024,8 +1028,7 @@ export class SheetBuilder {
         };
     }
 
-    // Return only program stages for which the current user has permissions to export/import data.
-    private getProgramStages() {
+    private getProgramStagesWithReadPermission() {
         const { element } = this.builder;
 
         return _(element.programStages)


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/86955vhn8

#86955vhn8

### :memo: Implementation

Right now in order to generate sheets for program stages the app check if the current user has read and write permissions to the program stage. In this PR I'm removing the write permission since we assume it's safe for the user to read the information. 

Asking @tokland for PR review in case this condition was added to cover any specific behaviour in the past.

### :fire: Notes for the reviewer

- Create a user with bulk load access and only read permissions to any program stage.
- Download template with data using the `Populate template with data` option
- It should download an excel file with the TEI and program stages information.

### :video_camera: Screenshots/Screen capture

**Program Stages sharing settings**
![image](https://github.com/user-attachments/assets/b65e85d5-6176-4ca0-8351-d5f463b5f2df)


**Download template option**
![image](https://github.com/user-attachments/assets/34b9d942-e7b4-4e43-b731-3060681ea097)


**Excel file**
![image](https://github.com/user-attachments/assets/e7beeb50-c7e1-4291-a16e-25a4bd6ae9e2)


### :bookmark_tabs: Others
