### PR TITLE
used response stats as fallback if `bundleReport.stats` is undefined

### DIFF
--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -36,12 +36,20 @@ export type ImportReportResponse = {
             }
         ];
     };
-    stats: ImportStats;
+    stats?: ImportStats;
     bundleReport?: {
         status: Status;
-        stats: ImportStats;
+        stats?: ImportStats;
         typeReportMap: TypeReportMap;
     };
+};
+
+const defaultStats = {
+    created: 0,
+    deleted: 0,
+    ignored: 0,
+    updated: 0,
+    total: 0,
 };
 
 export function processImportResponse(options: {
@@ -70,7 +78,14 @@ export function processImportResponse(options: {
             rawResponse: importResult,
         };
     }
-    const trackerStats = bundleReport.stats || importResult.stats;
+    const resStats = bundleReport.stats || importResult.stats;
+
+    if( !resStats ) {
+        console.error(`No 'stats' found in import response.`, importResult);
+    }
+
+    const trackerStats = resStats || defaultStats;
+
     const totalStats: SynchronizationStats = {
         type: "TOTAL",
         imported: trackerStats.created,

--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -70,11 +70,11 @@ export function processImportResponse(options: {
             rawResponse: importResult,
         };
     }
-
+    const trackerStats = bundleReport.stats || importResult.stats;
     const totalStats: SynchronizationStats = {
         type: "TOTAL",
-        imported: bundleReport.stats.created,
-        ...bundleReport.stats,
+        imported: trackerStats.created,
+        ...trackerStats,
     };
 
     const eventStatsList = _(bundleReport.typeReportMap)


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #8696ark8f

### :memo: Implementation

- updating response handling for `/tracker/jobs/<id>/report/`. Use response stats as fallback if `bundleReport.stats` is undefined.

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture
![image](https://github.com/user-attachments/assets/b8092524-02e0-4233-90a6-35e18e898de9)
![image](https://github.com/user-attachments/assets/4ed8e0c7-f63d-46dc-8956-e196ad8be009)
![image](https://github.com/user-attachments/assets/81a0fe01-d57e-4460-a774-233a8a544b77)
![image](https://github.com/user-attachments/assets/89c0a2a0-5aef-44be-b891-eb3c85889c00)


### :bookmark_tabs: Others
