### PR TITLE
Feature/download template redesign

### DIFF
--- a/src/webapp/components/collapsible-section/Section.tsx
+++ b/src/webapp/components/collapsible-section/Section.tsx
@@ -1,0 +1,89 @@
+import { Icon, IconButton, makeStyles, Paper } from "@material-ui/core";
+import React from "react";
+
+type iconPosition = "left" | "right";
+type arrowStyle = "upDown" | "rightLeft";
+
+export interface SectionProps {
+    isOpen?: boolean;
+    setOpen?: (open: boolean) => void;
+    children: React.ReactNode;
+    title: React.ReactNode;
+    collapsible?: boolean;
+    elevation?: number;
+    iconPos?: iconPosition;
+    classProps?: {
+        section?: string;
+        header?: string;
+        content?: string;
+    };
+    arrowStyle?: arrowStyle;
+}
+
+export const Section = ({
+    children,
+    title,
+    collapsible,
+    isOpen = true,
+    setOpen = () => {},
+    elevation = 1,
+    iconPos = "right",
+    classProps = {},
+    arrowStyle = "upDown",
+}: SectionProps) => {
+    const classes = useStyles();
+    const leftIcon = iconPos === "left" ? classes.leftIcon : null;
+    const toggle = () => setOpen(!isOpen);
+
+    return (
+        <Paper elevation={elevation} className={`${classes.paper} ${classProps.section}`}>
+            <div
+                className={`${classes.header} ${leftIcon} ${classProps.header} ${isOpen ? "" : classes.noBorder}`}
+                onClick={toggle}
+            >
+                {collapsible && leftIcon && <CollapsibleToggle isOpen={isOpen} arrowStyle={arrowStyle} />}
+                {title}
+                {collapsible && !leftIcon && <CollapsibleToggle isOpen={isOpen} arrowStyle={arrowStyle} />}
+            </div>
+            <div className={`${classProps.content}`} style={{ display: isOpen ? "" : "none" }}>
+                {children}
+            </div>
+        </Paper>
+    );
+};
+
+export interface CollapsibleToggleProps {
+    isOpen: boolean;
+    arrowStyle: "upDown" | "rightLeft";
+}
+
+export const CollapsibleToggle = ({ isOpen, arrowStyle }: CollapsibleToggleProps) => {
+    const classes = useStyles();
+    const [open, close] = arrowStyle === "upDown" ? ["up", "down"] : ["right", "left"];
+
+    return (
+        <IconButton disableTouchRipple={true} style={isOpen ? {} : { left: 0 }} className={classes.button}>
+            <Icon>{isOpen ? `keyboard_arrow_${open}` : `keyboard_arrow_${close}`}</Icon>
+        </IconButton>
+    );
+};
+
+const useStyles = makeStyles({
+    header: {
+        margin: 0,
+        padding: "1em",
+        paddingLeft: 0,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        borderBottom: "solid 1px #e8edf2",
+        cursor: "pointer",
+    },
+    noBorder: { border: "none" },
+    leftIcon: {
+        justifyContent: "normal",
+        gap: 10,
+    },
+    paper: { padding: "1em", paddingTop: "0.5em", marginBottom: "1em" },
+    button: { padding: 0 },
+});

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -291,10 +291,6 @@ export const TemplateSelector = ({
     const showPopulate = !(state.templateType === "custom" && !settings.showPopulateInCustomForms);
     const selected = state.id && state.templateId ? getOptionValue({ id: state.id, templateId: state.templateId }) : "";
 
-    useEffect(() => {
-        console.log(selectedOrgUnits);
-    }, [selectedOrgUnits]);
-
     return (
         <>
             <Section
@@ -321,6 +317,10 @@ export const TemplateSelector = ({
                         />
                     </div>
                 </div>
+
+                {state.type === "dataSets" && (
+                    <h4 className={classes.subSectionTitle}>Periods</h4>
+                )}
 
                 {state.type === "dataSets" && state.templateType === "custom" && showPopulate && (
                     <DatePicker


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #8694wfy5f

### :memo: Implementation

- added a section component to reuse styles and collapse function for the form sections
- divided fields into sections
- rearranged advanced options
- updated toggle `filterOrgUnits` logic. Remove clearing of populate, populate dates, and selectedOrgUnits (more notes in reviewers section)
- hide populate section until an orgUnit is selected. Previously depended on the org unit checkBox

### :fire: Notes for the reviewer
- hide populate section until an orgUnit is selected, otherwise the section is empty
- updated behavior of selecting organization unit.
	- PREVIOUSLY: when toggled, the following were cleared: selectedOrgUnits, populate, populate dates
	- NOW: collapsing implies a visual change not data change, so I removed data updates
- I opted to use up down arrows instead of left right as indicated in the task document. Seems to fit more with how the section collapses.
- I used the "Organisation Unit" label beside the toggle with an indicator of how many is selected (found it useful while testing so included it for now)

### :video_camera: Screenshots/Screen capture
![image](https://github.com/user-attachments/assets/fc6f31e3-7234-4f0e-becf-46ad74f7da47)

![image](https://github.com/user-attachments/assets/4f149d92-db8b-4e37-9e62-2ee222005d1f)

![image](https://github.com/user-attachments/assets/e30e8552-d420-46b6-b951-22dd4033d159)


### :bookmark_tabs: Others
