### PR TITLE
fix: teiId rowStart bug in program stage sheets

### DIFF
--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -333,7 +333,7 @@ export class ExcelBuilder {
                 .uniq()
                 .value();
 
-            const newTEIs = _.difference(allTEIs, existingTEIs);
+            const newTEIs = _.difference(allTEIs, existingTEIs).reverse(); // reverse the list
 
             return await promiseMap(newTEIs, async (id, index) => {
                 const teiRowStart = dataSource.dataValues.rowStart + newTEIs.length - index - 1; // reverse tei ids
@@ -343,9 +343,10 @@ export class ExcelBuilder {
                     rowEnd: teiRowStart,
                 });
 
+                const eventId = payload.dataEntries[index]?.id;
                 const teiIdCell = await this.excelRepository.findRelativeCell(template.id, dataSource.teiId, cells[0]);
 
-                if (teiIdCell && id) {
+                if (eventId && teiIdCell && id) {
                     await this.excelRepository.writeCell(template.id, teiIdCell, id);
                 }
             });

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -336,11 +336,11 @@ export class ExcelBuilder {
             const newTEIs = _.difference(allTEIs, existingTEIs);
 
             return await promiseMap(newTEIs, async (id, index) => {
-                const rowStart = dataSource.dataValues.rowStart + newTEIs.length - index - 1; // reverse tei ids
+                const teiRowStart = dataSource.dataValues.rowStart + newTEIs.length - index - 1; // reverse tei ids
                 const cells = await this.excelRepository.getCellsInRange(template.id, {
                     ...dataSource.dataValues,
-                    rowStart,
-                    rowEnd: rowStart,
+                    rowStart: teiRowStart,
+                    rowEnd: teiRowStart,
                 });
 
                 const teiIdCell = await this.excelRepository.findRelativeCell(template.id, dataSource.teiId, cells[0]);

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -335,7 +335,8 @@ export class ExcelBuilder {
 
             const newTEIs = _.difference(allTEIs, existingTEIs);
 
-            for (const id of newTEIs) {
+            return await promiseMap(newTEIs, async (id, index) => {
+                const rowStart = dataSource.dataValues.rowStart + newTEIs.length - index - 1; // reverse tei ids
                 const cells = await this.excelRepository.getCellsInRange(template.id, {
                     ...dataSource.dataValues,
                     rowStart,
@@ -347,9 +348,7 @@ export class ExcelBuilder {
                 if (teiIdCell && id) {
                     await this.excelRepository.writeCell(template.id, teiIdCell, id);
                 }
-
-                rowStart += 1;
-            }
+            });
         }
     }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8697n6kzy

### :memo: Implementation
- [x] Show TEI IDs for corresponding events in program stage sheets

### :fire: Notes for the reviewer
- Add program stage ID to dataStore in bulk-load/BULK_LOAD_SETTINGS to `programStagePopulateEventsForEveryTei` object:
<img width="563" alt="Screenshot 2025-01-29 at 18 09 59" src="https://github.com/user-attachments/assets/43ad08a7-9cc7-403a-a1b6-77e4b437cbbe" />

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/ce926692-3963-4a10-b8fe-3695609c1673


### :bookmark_tabs: Others

#8697n6kzy