### PR TITLE
fix errors in export event program and tracker program

### DIFF
--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -12,6 +12,7 @@ import { getUid } from "./dhis2-uid";
 import { getTrackedEntities, TrackedEntityGetRequest } from "./Dhis2TrackedEntityInstances";
 import { TrackerRelationship, RelationshipItem, TrackedEntitiesApiRequest } from "../domain/entities/TrackedEntity";
 import { buildOrgUnitsParameter } from "../domain/entities/OrgUnit";
+import { EventsAPIResponse } from "../domain/entities/DhisDataPackage";
 
 type RelationshipTypesById = Record<Id, Pick<D2RelationshipType, "id" | "toConstraint" | "fromConstraint">>;
 
@@ -295,11 +296,10 @@ async function getConstraintForTypeProgram(
         pageSize: number;
     }) {
         const { program, programStage, orgUnit, page, pageSize } = options;
-
-        return await api
-            .get<{ instances: { event: Id }[]; pageCount: number }>("/tracker/events", {
+        const { instances, events, pageCount } = await api
+            .get<EventsAPIResponse>("/tracker/events", {
                 program: program,
-                programStage: programStage,
+                ...(programStage && { programStage }),
                 orgUnit: orgUnit,
                 occurredAfter: startDate ? moment(startDate).format("YYYY-MM-DD") : undefined,
                 occurredBefore: endDate ? moment(endDate).format("YYYY-MM-DD") : undefined,
@@ -309,6 +309,11 @@ async function getConstraintForTypeProgram(
                 totalPages: true,
             })
             .getData();
+        const instanceEventIds = (instances || events || []).reduce((acc, { event }) => {
+            if (event) acc.push({ event });
+            return acc;
+        }, [] as { event: Id }[]);
+        return { instances: instanceEventIds, pageCount };
     }
 
     const events = await promiseMap(organisationUnits, async orgUnit => {

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -22,10 +22,13 @@ export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits?: R
     const isOuReq = ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS";
     //issue: v41 - orgUnitMode/ouMode; v38-40 ouMode; ouMode to be deprecated
     //can't use both orgUnitMode and ouMode in v41
-    return {
-        ouMode,
-        ...(isOuReq && { orgUnit: orgUnits?.length ? buildOrgUnitsParameter(orgUnits) : "" }),
-    };
+    if (!isOuReq) {
+        return { ouMode };
+    } else if (orgUnits && orgUnits.length > 0) {
+        return { ouMode, orgUnit: buildOrgUnitsParameter(orgUnits) };
+    } else {
+        throw new Error(`Invalid orgUnit (${orgUnits} for ouMode ${ouMode}`);
+    }
 }
 
 export function getApiRelationships(

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -27,7 +27,7 @@ export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits?: R
     } else if (orgUnits && orgUnits.length > 0) {
         return { ouMode, orgUnit: buildOrgUnitsParameter(orgUnits) };
     } else {
-        throw new Error(`Invalid orgUnit (${orgUnits} for ouMode ${ouMode}`);
+        throw new Error(`No orgUnits selected for ouMode ${ouMode}`);
     }
 }
 

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -18,13 +18,13 @@ type RelationshipTypesById = Record<Id, Pick<D2RelationshipType, "id" | "toConst
 
 export type RelationshipOrgUnitFilter = TrackedEntityOURequestApi["ouMode"];
 
-export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits: Ref[]) {
+export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits?: Ref[]) {
     const isOuReq = ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS";
     //issue: v41 - orgUnitMode/ouMode; v38-40 ouMode; ouMode to be deprecated
     //can't use both orgUnitMode and ouMode in v41
     return {
         ouMode,
-        ...(isOuReq && orgUnits && { orgUnit: buildOrgUnitsParameter(orgUnits) }),
+        ...(isOuReq && { orgUnit: orgUnits?.length ? buildOrgUnitsParameter(orgUnits) : "" }),
     };
 }
 

--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -18,6 +18,16 @@ type RelationshipTypesById = Record<Id, Pick<D2RelationshipType, "id" | "toConst
 
 export type RelationshipOrgUnitFilter = TrackedEntityOURequestApi["ouMode"];
 
+export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits: Ref[]) {
+    const isOuReq = ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS";
+    //issue: v41 - orgUnitMode/ouMode; v38-40 ouMode; ouMode to be deprecated
+    //can't use both orgUnitMode and ouMode in v41
+    return {
+        ouMode,
+        ...(isOuReq && orgUnits && { orgUnit: buildOrgUnitsParameter(orgUnits) }),
+    };
+}
+
 export function getApiRelationships(
     existingTei: TrackedEntityInstance | undefined,
     relationships: Relationship[],
@@ -239,10 +249,7 @@ async function getConstraintForTypeTei(
     const { ouMode = "CAPTURE", organisationUnits = [] } = filters || {};
     const trackedEntityTypesById = _.keyBy(trackedEntityTypes, obj => obj.id);
 
-    const ouModeQuery =
-        ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS"
-            ? { orgUnitMode: ouMode, orgUnit: organisationUnits ? buildOrgUnitsParameter(organisationUnits) : "" }
-            : { orgUnitMode: ouMode };
+    const ouModeQuery = buildOrgUnitMode(ouMode, organisationUnits);
 
     const query = {
         ...ouModeQuery,

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -25,7 +25,12 @@ import {
     RelationshipOrgUnitFilter,
 } from "./Dhis2RelationshipTypes";
 import { ImportPostResponse, postImport } from "./Dhis2Import";
-import { TrackedEntitiesApiRequest, TrackedEntitiesResponse, TrackedEntity } from "../domain/entities/TrackedEntity";
+import {
+    TrackedEntitiesApiRequest,
+    TrackedEntitiesResponse,
+    TrackedEntity,
+    TrackedEntitiesAPIResponse,
+} from "../domain/entities/TrackedEntity";
 import { Params } from "@eyeseetea/d2-api/api/common";
 import { buildOrgUnitsParameter } from "../domain/entities/OrgUnit";
 
@@ -483,11 +488,11 @@ export async function getTrackedEntities(
     api: D2Api,
     filterQuery: TrackedEntityGetRequest
 ): Promise<TrackedEntitiesResponse> {
-    const { instances, pageCount } = await api
-        .get<TrackedEntitiesResponse>("/tracker/trackedEntities", filterQuery)
+    const { instances, trackedEntities, pageCount } = await api
+        .get<TrackedEntitiesAPIResponse>("/tracker/trackedEntities", filterQuery)
         .getData();
 
-    return { instances: instances, pageCount: pageCount };
+    return { instances: instances || trackedEntities || [], pageCount: pageCount };
 }
 
 function buildTei(

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -18,6 +18,7 @@ import { promiseMap } from "../utils/promises";
 import { getUid } from "./dhis2-uid";
 import { postEvents } from "./Dhis2Events";
 import {
+    buildOrgUnitMode,
     fromApiRelationships,
     getApiRelationships,
     getRelationshipMetadata,
@@ -32,7 +33,6 @@ import {
     TrackedEntitiesAPIResponse,
 } from "../domain/entities/TrackedEntity";
 import { Params } from "@eyeseetea/d2-api/api/common";
-import { buildOrgUnitsParameter } from "../domain/entities/OrgUnit";
 
 export interface GetOptions {
     api: D2Api;
@@ -463,10 +463,7 @@ async function getTeisFromApi(options: {
         "geometry",
     ];
 
-    const ouModeQuery =
-        ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS"
-            ? { ouMode: ouMode, orgUnit: orgUnits ? buildOrgUnitsParameter(orgUnits) : "" }
-            : { ouMode: ouMode };
+    const ouModeQuery = buildOrgUnitMode(ouMode, orgUnits);
 
     const filters: TrackedEntityGetRequest = {
         ...ouModeQuery,

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -3,7 +3,14 @@ import "lodash.product";
 import moment from "moment";
 import { DataElement, DataForm, DataFormPeriod, DataFormType } from "../domain/entities/DataForm";
 import { DataPackage, TrackerProgramPackage } from "../domain/entities/DataPackage";
-import { AggregatedDataValue, AggregatedPackage, Event, EventsPackage } from "../domain/entities/DhisDataPackage";
+import {
+    AggregatedDataValue,
+    AggregatedPackage,
+    Event,
+    EventsAPIResponse,
+    EventsPackage,
+    EventsResponse,
+} from "../domain/entities/DhisDataPackage";
 import { DhisInstance } from "../domain/entities/DhisInstance";
 import { Locale } from "../domain/entities/Locale";
 import { OrgUnit } from "../domain/entities/OrgUnit";
@@ -616,19 +623,9 @@ export class InstanceDhisRepository implements InstanceRepository {
             throw new Error(`Could not find category options for the program ${id}`);
         }
 
-        const getEvents = async (
-            orgUnit: Id,
-            categoryOptionId: Id,
-            page: number
-        ): Promise<{
-            instances: Event[];
-            pageCount: number;
-        }> => {
-            const { instances, pageCount } = await this.api
-                .get<{
-                    instances: Event[];
-                    pageCount: number;
-                }>("/tracker/events", {
+        const getEvents = async (orgUnit: Id, categoryOptionId: Id, page: number): Promise<EventsResponse> => {
+            const { instances, events, pageCount } = await this.api
+                .get<EventsAPIResponse>("/tracker/events", {
                     program: id,
                     orgUnit,
                     paging: true,
@@ -645,7 +642,7 @@ export class InstanceDhisRepository implements InstanceRepository {
                 })
                 .getData();
 
-            return { instances, pageCount };
+            return { instances: instances || events || [], pageCount };
         };
 
         const programEvents: Event[] = [];

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -35,6 +35,16 @@ export interface Event {
     dataValues: EventDataValue[];
 }
 
+export type EventsResponse = {
+    instances: Event[];
+    pageCount: number;
+};
+
+export type EventsAPIResponse = Omit<EventsResponse, "instances"> & {
+    instances?: Event[];
+    events?: Event[];
+};
+
 type Coordinates = [number, number];
 
 export type Geometry =

--- a/src/domain/entities/TrackedEntity.ts
+++ b/src/domain/entities/TrackedEntity.ts
@@ -48,3 +48,8 @@ export type TrackedEntitiesResponse = {
     instances: TrackedEntitiesApiRequest[];
     pageCount: number;
 };
+
+export type TrackedEntitiesAPIResponse = Omit<TrackedEntitiesResponse, "instances"> & {
+    instances?: TrackedEntitiesApiRequest[];
+    trackedEntities?: TrackedEntitiesApiRequest[];
+};


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #8697re161

### :memo: Implementation
- updated response handling for `/tracker/events` and `/tracker/trackedEntities` to use a fallback (instances || (events/trackedEntities) || []
- updated `/tracker/events` payload to not include `programStage` when it is null
- use ouMode for calls to /tracker/trackedEntities

### :fire: Notes for the reviewer
- v38-40: compatible with ouMode only
- v41: compatible with ouMode and orgUnitMode. Can't send both on v41 so I used ouMode for all
- v41: error when programStage is empty

### :video_camera: Screenshots/Screen capture
![image](https://github.com/user-attachments/assets/c74aa168-30c6-407c-86b9-7ef09b42c4d5)
![image](https://github.com/user-attachments/assets/5e610375-70e1-41f7-b05e-40a67b720f3a)
![image](https://github.com/user-attachments/assets/9bf364f6-7ea7-4eb7-8b80-ec04c88167b0)

### :bookmark_tabs: Others
