### PR TITLE
set enrollment for events, remove optionId validation

### DIFF
--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -5,15 +5,16 @@ import { SynchronizationResult } from "../domain/entities/SynchronizationResult"
 import i18n from "../locales";
 import { promiseMap } from "../utils/promises";
 import { ImportPostResponse, postImport } from "./Dhis2Import";
-import { TrackedEntityInstance } from "../domain/entities/TrackedEntityInstance";
-import { getUid } from "./dhis2-uid";
+import { Program, TrackedEntityInstance } from "../domain/entities/TrackedEntityInstance";
+import { getApiTeiToUpload, Metadata } from "./Dhis2TrackedEntityInstances";
+import { Maybe } from "../types/utils";
 
 export async function postEvents(
     api: D2Api,
     events: Event[],
-    options: { existingTeis: TrackedEntityInstance[]; teis: TrackedEntityInstance[] }
+    options: Maybe<OptionEvents>
 ): Promise<SynchronizationResult[]> {
-    const eventsWithEnrollment = setEnrollmentToEvent(events, options);
+    const eventsWithEnrollment = options ? setEnrollmentToEvent(events, options) : events;
 
     const eventsResult = await promiseMap(_.chunk(eventsWithEnrollment, 200), eventsToSave => {
         return postImport(
@@ -30,18 +31,24 @@ export async function postEvents(
     return eventsResult;
 }
 
-function setEnrollmentToEvent(
-    events: Event[],
-    options: { existingTeis: TrackedEntityInstance[]; teis: TrackedEntityInstance[] }
-) {
-    const { existingTeis, teis } = options;
-    return teis.length === 0
-        ? events
-        : events.map(event => {
-              const existingTei = existingTeis.find(tei => tei.id === event.trackedEntity);
-              const tei = teis.find(tei => tei.id === event.trackedEntity);
-              if (!tei) return event;
-              const enrollmentId = existingTei?.enrollment?.id || getUid([tei.id, tei.orgUnit, tei.program].join("-"));
-              return { ...event, enrollment: enrollmentId };
-          });
+function setEnrollmentToEvent(events: Event[], options: OptionEvents): Event[] {
+    const { existingTeis, teis, program, metadata } = options;
+    const apiTeis = teis.map(tei => getApiTeiToUpload(program, metadata, tei, existingTeis));
+    const teisByIds = _.keyBy(apiTeis, tei => tei.trackedEntity);
+    return events.map(event => {
+        const eventTeiId = event.trackedEntity ?? "";
+        const tei = teisByIds[eventTeiId];
+        const enrollmentId = tei?.enrollments[0]?.enrollment;
+        if (!enrollmentId) {
+            throw new Error(`Enrollment not found for event-tei: ${eventTeiId}-${event.trackedEntity}`);
+        }
+        return { ...event, enrollment: enrollmentId };
+    });
 }
+
+type OptionEvents = {
+    existingTeis: TrackedEntityInstance[];
+    teis: TrackedEntityInstance[];
+    program: Program;
+    metadata: Metadata;
+};

--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -5,9 +5,17 @@ import { SynchronizationResult } from "../domain/entities/SynchronizationResult"
 import i18n from "../locales";
 import { promiseMap } from "../utils/promises";
 import { ImportPostResponse, postImport } from "./Dhis2Import";
+import { TrackedEntityInstance } from "../domain/entities/TrackedEntityInstance";
+import { getUid } from "./dhis2-uid";
 
-export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult[]> {
-    const eventsResult = await promiseMap(_.chunk(events, 200), eventsToSave => {
+export async function postEvents(
+    api: D2Api,
+    events: Event[],
+    options: { existingTeis: TrackedEntityInstance[]; teis: TrackedEntityInstance[] }
+): Promise<SynchronizationResult[]> {
+    const eventsWithEnrollment = setEnrollmentToEvent(events, options);
+
+    const eventsResult = await promiseMap(_.chunk(eventsWithEnrollment, 200), eventsToSave => {
         return postImport(
             api,
             async () => await api.post<ImportPostResponse>("/tracker", {}, { events: eventsToSave }).getData(),
@@ -20,4 +28,20 @@ export async function postEvents(api: D2Api, events: Event[]): Promise<Synchroni
     });
 
     return eventsResult;
+}
+
+function setEnrollmentToEvent(
+    events: Event[],
+    options: { existingTeis: TrackedEntityInstance[]; teis: TrackedEntityInstance[] }
+) {
+    const { existingTeis, teis } = options;
+    return teis.length === 0
+        ? events
+        : events.map(event => {
+              const existingTei = existingTeis.find(tei => tei.id === event.trackedEntity);
+              const tei = teis.find(tei => tei.id === event.trackedEntity);
+              if (!tei) return event;
+              const enrollmentId = existingTei?.enrollment?.id || getUid([tei.id, tei.orgUnit, tei.program].join("-"));
+              return { ...event, enrollment: enrollmentId };
+          });
 }

--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -80,7 +80,7 @@ export function processImportResponse(options: {
     }
     const resStats = bundleReport.stats || importResult.stats;
 
-    if( !resStats ) {
+    if (!resStats) {
         console.error(`No 'stats' found in import response.`, importResult);
     }
 

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -18,6 +18,7 @@ import { promiseMap } from "../utils/promises";
 import { getUid } from "./dhis2-uid";
 import { postEvents } from "./Dhis2Events";
 import {
+    buildOrgUnitMode,
     fromApiRelationships,
     getApiRelationships,
     getRelationshipMetadata,
@@ -27,7 +28,6 @@ import {
 import { ImportPostResponse, postImport } from "./Dhis2Import";
 import { TrackedEntitiesApiRequest, TrackedEntitiesResponse, TrackedEntity } from "../domain/entities/TrackedEntity";
 import { Params } from "@eyeseetea/d2-api/api/common";
-import { buildOrgUnitsParameter } from "../domain/entities/OrgUnit";
 
 export interface GetOptions {
     api: D2Api;
@@ -458,10 +458,7 @@ async function getTeisFromApi(options: {
         "geometry",
     ];
 
-    const ouModeQuery =
-        ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS"
-            ? { ouMode: ouMode, orgUnit: orgUnits ? buildOrgUnitsParameter(orgUnits) : "" }
-            : { ouMode: ouMode };
+    const ouModeQuery = buildOrgUnitMode(ouMode, orgUnits);
 
     const filters: TrackedEntityGetRequest = {
         ...ouModeQuery,

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -166,7 +166,7 @@ export async function updateTrackedEntityInstances(
     return runSequentialPromisesOnSuccess([
         () => uploadTeis({ ...options, teis: preTeis, title: i18n.t("Create/update") }),
         () => uploadTeis({ ...options, teis: postTeis, title: i18n.t("Relationships") }),
-        () => postEvents(api, apiEvents, { existingTeis, teis: preTeis.concat(postTeis) }),
+        () => postEvents(api, apiEvents, { existingTeis, teis: teis, program, metadata }),
     ]);
 }
 
@@ -257,7 +257,7 @@ async function uploadTeis(options: {
     return teisResult;
 }
 
-interface Metadata {
+export interface Metadata {
     options: Array<{ id: Id; code: string }>;
     relationshipTypesById: Record<Id, Pick<D2RelationshipType, "id" | "toConstraint" | "fromConstraint">>;
 }
@@ -353,7 +353,7 @@ async function getApiEvents(
         .value();
 }
 
-function getApiTeiToUpload(
+export function getApiTeiToUpload(
     program: Program,
     metadata: Metadata,
     tei: TrackedEntityInstance,
@@ -365,7 +365,7 @@ function getApiTeiToUpload(
     const existingTei = existingTeis.find(tei_ => tei_.id === tei.id);
     const apiRelationships = getApiRelationships(existingTei, relationships, metadata.relationshipTypesById);
 
-    const enrollmentId = existingTei?.enrollment?.id || getUid([tei.id, orgUnit.id, program.id].join("-"));
+    const enrollmentId = existingTei?.enrollment?.id || generateUidForTei(tei.id, orgUnit.id, program.id);
 
     const attributes = tei.attributeValues.map(attributeValue => ({
         attribute: attributeValue.attribute.id,
@@ -591,4 +591,8 @@ function getValue(
     } else {
         return dataValue.value.toString();
     }
+}
+
+export function generateUidForTei(teiId: Id, orgUnitId: Id, programId: Id): string {
+    return getUid([teiId, orgUnitId, programId].join("-"));
 }

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -166,7 +166,7 @@ export async function updateTrackedEntityInstances(
     return runSequentialPromisesOnSuccess([
         () => uploadTeis({ ...options, teis: preTeis, title: i18n.t("Create/update") }),
         () => uploadTeis({ ...options, teis: postTeis, title: i18n.t("Relationships") }),
-        () => postEvents(api, apiEvents),
+        () => postEvents(api, apiEvents, { existingTeis, teis: preTeis.concat(postTeis) }),
     ]);
 }
 
@@ -589,7 +589,7 @@ function getValue(
     dataValue: { optionId?: string; value: EventDataValue["value"] },
     optionById: Record<Id, { id: Id; code: string } | undefined>
 ): string {
-    if (dataValue.optionId && dataValue.optionId !== "true" && dataValue.optionId !== "false") {
+    if (dataValue.optionId) {
         return optionById[dataValue.optionId]?.code || dataValue.optionId;
     } else {
         return dataValue.value.toString();

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -459,7 +459,8 @@ export class InstanceDhisRepository implements InstanceRepository {
             };
         });
 
-        return postEvents(this.api, eventsToSave, { existingTeis: [], teis: [] });
+        // third value only required for program trackers
+        return postEvents(this.api, eventsToSave, undefined);
     }
 
     private async getEventProgramStage(programId: Id): Promise<Ref | undefined> {

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -459,7 +459,7 @@ export class InstanceDhisRepository implements InstanceRepository {
             };
         });
 
-        return postEvents(this.api, eventsToSave);
+        return postEvents(this.api, eventsToSave, { existingTeis: [], teis: [] });
     }
 
     private async getEventProgramStage(programId: Id): Promise<Ref | undefined> {

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -342,6 +342,7 @@ export class SheetBuilder {
 
                     if (description !== undefined) {
                         // TODO: adding description as a comment is generating an error in excel
+                        // More details here: https://github.com/EyeSeeTea/Bulk-Load/pull/348
                         // sheet.cell(itemRow, columnId).comment(description, {
                         //     height: "100pt",
                         //     width: "160pt",

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -341,10 +341,11 @@ export class SheetBuilder {
                     }
 
                     if (description !== undefined) {
-                        sheet.cell(itemRow, columnId).comment(description, {
-                            height: "100pt",
-                            width: "160pt",
-                        });
+                        // TODO: adding description as a comment is generating an error in excel
+                        // sheet.cell(itemRow, columnId).comment(description, {
+                        //     height: "100pt",
+                        //     width: "160pt",
+                        // });
                     }
 
                     columnId++;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/8697qpqp6

### :memo: Implementation

- [x] Include enrollment property for events because in the new endpoint `POST /tracker` this is [is required for events](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-238/new-tracker.html#events)
![image](https://github.com/user-attachments/assets/bee7c4c0-05a3-45fd-b1e8-8a864e906537)

- Parse `yes/no` values to `true/false` to avoid validation errors with boolean attributes

**UPDATE 2025-02-09**

- Remove comments in program stages to avoid error in excel:

```
we found a problem with some content in excel do you want us to recover as much as we can
```

Right now the library is generating comments with this xml structure:

```xml
<comment ref="E2" authorId="0">
	<text>
		<t>TESTS</t>
	</text>
</comment>
```

and it looks like the "right" xml for excel should be:

```xml
<comment ref="E2" authorId="0">
	<text>
		<r>
			<rPr>
				<sz val="10"/>
				<color indexed="81"/>
				<rFont val="Tahoma"/>
				<family val="2"/>
			</rPr>
			<t>TESTS</t>
		</r>
	</text>
</comment>
```

I'm removing the comments, but when we have more time we can check if adding[ this new structure to the library](https://github.com/EyeSeeTea/xlsx-populate/blob/master/lib/Workbook.js#L357) fix the problem without conflicts with open office.

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others

#8697qpqp6