### PR TITLE
Fix: missing template tei ids

### DIFF
--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -2,7 +2,6 @@ import { TeiGetRequest, TrackedEntityInstanceGeometryAttributes } from "@eyeseet
 import { generateUid } from "d2/uid";
 import _ from "lodash";
 import { Moment } from "moment";
-import { DataElementType } from "../domain/entities/DataForm";
 import { ProgramPackageData } from "../domain/entities/DataPackage";
 import { Event, EventDataValue } from "../domain/entities/DhisDataPackage";
 import { Geometry } from "../domain/entities/Geometry";

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -3,7 +3,7 @@ import { generateUid } from "d2/uid";
 import _ from "lodash";
 import { Moment } from "moment";
 import { DataElementType } from "../domain/entities/DataForm";
-import { DataPackageData } from "../domain/entities/DataPackage";
+import { ProgramPackageData } from "../domain/entities/DataPackage";
 import { Event, EventDataValue } from "../domain/entities/DhisDataPackage";
 import { Geometry } from "../domain/entities/Geometry";
 import { emptyImportSummary } from "../domain/entities/ImportSummary";
@@ -137,7 +137,7 @@ export async function getProgram(api: D2Api, id: Id): Promise<Program | undefine
 export async function updateTrackedEntityInstances(
     api: D2Api,
     trackedEntityInstances: TrackedEntityInstance[],
-    dataEntries: DataPackageData[]
+    dataEntries: ProgramPackageData[]
 ): Promise<SynchronizationResult[]> {
     if (_.isEmpty(trackedEntityInstances)) return [emptyImportSummary];
 
@@ -284,7 +284,7 @@ async function getMetadata(api: D2Api): Promise<Metadata> {
 async function getApiEvents(
     api: D2Api,
     teis: TrackedEntityInstance[],
-    dataEntries: DataPackageData[],
+    dataEntries: ProgramPackageData[],
     metadata: Metadata,
     teiSeed: string
 ): Promise<Event[]> {

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -209,7 +209,7 @@ export class ExcelPopulateRepository extends ExcelRepository {
 
         const formulaValue = getFormulaValue();
         const textValue = getValue(destination);
-        const value = formula ? formulaValue : this.resolveNA(textValue ?? "", formulaValue ?? "");
+        const value = formula ? formulaValue : this.resolveNA(textValue, formulaValue);
 
         if (value instanceof FormulaError) return "";
 
@@ -230,9 +230,9 @@ export class ExcelPopulateRepository extends ExcelRepository {
     // can be used as a workaround:
     // formulas that result to blank cells store the raw formula in the value
     // use #N/A as default value instead of blank
-    private resolveNA(value: ExcelValue, formula: ExcelValue): ExcelValue {
+    private resolveNA(value: Maybe<ExcelValue>, formula: Maybe<ExcelValue>): Maybe<ExcelValue> {
         if (value === "#N/A") return "";
-        return value || formula;
+        return value ?? formula;
     }
 
     public async getCellsInRange(id: string, range: Range): Promise<CellRef[]> {

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -25,7 +25,7 @@ import i18n from "../utils/i18n";
 import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
 import { removeCharacters } from "../utils/string";
-import { Optional } from "../types/utils";
+import { Maybe } from "../types/utils";
 
 export class ExcelPopulateRepository extends ExcelRepository {
     private workbooks: Record<string, ExcelWorkbook> = {};
@@ -139,7 +139,7 @@ export class ExcelPopulateRepository extends ExcelRepository {
         return this.readCellValue(workbook, cellRef, options?.formula);
     }
 
-    public async getContentType(id: string, cellRef?: CellRef | ValueRef): Promise<Optional<ContentType>> {
+    public async getContentType(id: string, cellRef?: CellRef | ValueRef): Promise<Maybe<ContentType>> {
         if (!cellRef) return undefined;
         if (cellRef.type === "value") return "raw";
 

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -232,7 +232,7 @@ export class ExcelPopulateRepository extends ExcelRepository {
     // use #N/A as default value instead of blank
     private resolveNA(value: ExcelValue, formula: ExcelValue): ExcelValue {
         if (value === "#N/A") return "";
-        return value ?? formula;
+        return value || formula;
     }
 
     public async getCellsInRange(id: string, range: Range): Promise<CellRef[]> {

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -346,14 +346,13 @@ export class InstanceDhisRepository implements InstanceRepository {
     private buildAggregatedPayload(dataPackage: DataPackage): AggregatedDataValue[] {
         if (dataPackage.type !== dataFormTypeMap.dataSets) return [];
         return _.flatMap(dataPackage.dataEntries, ({ orgUnit, period, attribute, dataValues }) =>
-            dataValues.map(({ dataElement, category, value, comment }: DataSetPackageDataValue) => ({
+            dataValues.map(({ dataElement, category, value }: DataSetPackageDataValue) => ({
                 orgUnit,
                 period,
                 attributeOptionCombo: attribute,
                 dataElement,
                 categoryOptionCombo: category,
                 value: String(value),
-                comment,
             }))
         );
     }

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -347,13 +347,14 @@ export class InstanceDhisRepository implements InstanceRepository {
     private buildAggregatedPayload(dataPackage: DataPackage): AggregatedDataValue[] {
         if (dataPackage.type !== dataFormTypeMap.dataSets) return [];
         return _.flatMap(dataPackage.dataEntries, ({ orgUnit, period, attribute, dataValues }) =>
-            dataValues.map(({ dataElement, category, value }: DataSetPackageDataValue) => ({
+            dataValues.map(({ dataElement, category, value, comment }: DataSetPackageDataValue) => ({
                 orgUnit,
                 period,
                 attributeOptionCombo: attribute,
                 dataElement,
                 categoryOptionCombo: category,
                 value: String(value),
+                comment,
             }))
         );
     }

--- a/src/data/templates/snakebite-annual-report/SnakebiteAnnualReport.01.ts
+++ b/src/data/templates/snakebite-annual-report/SnakebiteAnnualReport.01.ts
@@ -2,13 +2,13 @@ import { generateUid } from "d2/uid";
 import _ from "lodash";
 import { Codec } from "purify-ts";
 import { DataElement, DataForm } from "../../../domain/entities/DataForm";
-import { DataPackage } from "../../../domain/entities/DataPackage";
 import {
     CustomTemplateWithUrl,
     DataSource,
     DownloadCustomizationOptions,
     ImportCustomizationOptions,
     StyleSource,
+    TemplateDataPackage,
 } from "../../../domain/entities/Template";
 import { ThemeStyle } from "../../../domain/entities/Theme";
 import { ExcelRepository } from "../../../domain/repositories/ExcelRepository";
@@ -487,7 +487,7 @@ export class SnakebiteAnnualReport implements CustomTemplateWithUrl {
         _excelRepository: ExcelRepository,
         instanceRepository: InstanceRepository,
         options: ImportCustomizationOptions
-    ): Promise<DataPackage | undefined> {
+    ): Promise<TemplateDataPackage | undefined> {
         const { dataPackage } = options;
         const dataSet = await this.getDataForms(instanceRepository);
 

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -2,13 +2,12 @@ import i18n from "../../utils/i18n";
 import { ofType } from "../../types/utils";
 import { Id, NamedRef } from "./ReferenceObject";
 
-export const dataFormTypesMap = {
-    dataSets: "dataSet",
+export const dataFormTypeMap = {
+    dataSets: "dataSets",
     programs: "programs",
-    trackerPrograms: "trackerProgram",
+    trackerPrograms: "trackerPrograms",
 } as const;
-
-export const dataFormTypes = Object.keys(dataFormTypesMap) as (keyof typeof dataFormTypesMap)[];
+export const dataFormTypes = Object.values(dataFormTypeMap) as typeof dataFormTypeMap[keyof typeof dataFormTypeMap][];
 export type DataFormType = typeof dataFormTypes[number];
 export type DataFormPeriod = "Daily" | "Monthly" | "Yearly" | "Weekly" | "Quarterly";
 

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -2,7 +2,13 @@ import i18n from "../../utils/i18n";
 import { ofType } from "../../types/utils";
 import { Id, NamedRef } from "./ReferenceObject";
 
-export const dataFormTypes = ["dataSets", "programs", "trackerPrograms"] as const;
+export const dataFormTypesMap = {
+    dataSets: "dataSet",
+    programs: "programs",
+    trackerPrograms: "trackerProgram",
+} as const;
+
+export const dataFormTypes = Object.keys(dataFormTypesMap) as (keyof typeof dataFormTypesMap)[];
 export type DataFormType = typeof dataFormTypes[number];
 export type DataFormPeriod = "Daily" | "Monthly" | "Yearly" | "Weekly" | "Quarterly";
 

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -65,4 +65,5 @@ export type BasePackageDataValue = {
 
 export type DataSetPackageDataValue = BasePackageDataValue & {
     category: Maybe<Id>;
+    comment?: string;
 };

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -64,11 +64,3 @@ export type DataSetPackageDataValue = BasePackageDataValue & {
     category: Maybe<Id>;
     comment: Maybe<string>;
 };
-
-export function hasProgramPackageData(pkg: DataPackage): pkg is EventProgramPackage | TrackerProgramPackage {
-    return pkg.type === "programs" || pkg.type === "trackerPrograms";
-}
-
-export function isDataSet(entry: BaseDataPackage): entry is DataSetPackage {
-    return entry.type === "dataSets";
-}

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -1,44 +1,74 @@
 import { DataFormType } from "./DataForm";
 import { Id } from "./ReferenceObject";
 import { TrackedEntityInstance } from "./TrackedEntityInstance";
+import { Maybe } from "../../types/utils";
+import { Geometry } from "./DhisDataPackage";
 
-export type DataPackage = GenericProgramPackage | TrackerProgramPackage;
+export type DataPackage = DataSetPackage | EventProgramPackage | TrackerProgramPackage;
 export type DataPackageValue = string | number | boolean;
+export type DataPackageData = BasePackageData | DataSetPackageData | ProgramPackageData;
+export type DataPackageDataValue = BasePackageDataValue | DataSetPackageDataValue;
 
-export interface BaseDataPackage {
+interface BaseDataPackage {
     type: DataFormType;
-    dataEntries: DataPackageData[];
+    dataEntries: BasePackageData[];
 }
 
-export interface GenericProgramPackage extends BaseDataPackage {
-    type: "dataSets" | "programs";
-}
+type DataSetPackage = BaseDataPackage & {
+    type: "dataSets";
+    dataEntries: DataSetPackageData[];
+};
 
-export interface TrackerProgramPackage extends BaseDataPackage {
+type EventProgramPackage = BaseDataPackage & {
+    type: "programs";
+    dataEntries: ProgramPackageData[];
+};
+
+export type TrackerProgramPackage = BaseDataPackage & {
     type: "trackerPrograms";
     trackedEntityInstances: TrackedEntityInstance[];
-}
+    dataEntries: ProgramPackageData[];
+};
 
-export interface DataPackageData {
-    group?: number | string;
-    id?: Id;
-    dataForm: Id;
+type BasePackageData = {
     orgUnit: Id;
+    dataForm: Id;
     period: string;
-    attribute?: Id;
-    trackedEntityInstance?: Id;
-    programStage?: Id;
-    coordinate?: {
+    attribute: Maybe<Id>;
+    dataValues: (BasePackageDataValue | DataSetPackageDataValue)[];
+};
+
+export type DataSetPackageData = BasePackageData & {
+    type: "aggregated";
+    dataValues: DataSetPackageDataValue[];
+};
+
+export type ProgramPackageData = BasePackageData & {
+    id: Maybe<Id>;
+    trackedEntityInstance: Maybe<Id>;
+    programStage: Maybe<Id>;
+    coordinate: Maybe<{
         latitude: string;
         longitude: string;
-    };
-    dataValues: DataPackageDataValue[];
+    }>;
+    dataValues: BasePackageDataValue[];
+    geometry: Maybe<Geometry>;
+};
+
+export type BasePackageDataValue = {
+    dataElement: Id;
+    value: DataPackageValue;
+};
+
+export type DataSetPackageDataValue = BasePackageDataValue & {
+    category: Maybe<Id>;
+    comment: Maybe<string>;
+};
+
+export function hasProgramPackageData(pkg: DataPackage): pkg is EventProgramPackage | TrackerProgramPackage {
+    return pkg.type === "programs" || pkg.type === "trackerPrograms";
 }
 
-export interface DataPackageDataValue {
-    dataElement: Id;
-    category?: Id;
-    value: DataPackageValue;
-    optionId?: Id;
-    comment?: string;
+export function isDataSet(entry: BaseDataPackage): entry is DataSetPackage {
+    return entry.type === "dataSets";
 }

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -60,7 +60,6 @@ export type BasePackageDataValue = {
     dataElement: Id;
     value: DataPackageValue;
     optionId?: Id;
-    comment?: string;
     contentType?: ContentType;
 };
 

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -62,5 +62,4 @@ export type BasePackageDataValue = {
 
 export type DataSetPackageDataValue = BasePackageDataValue & {
     category: Maybe<Id>;
-    comment: Maybe<string>;
 };

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -62,7 +62,7 @@ export type BasePackageDataValue = {
     optionId?: Id;
     comment?: string;
     contentType?: ContentType;
-}
+};
 
 export type DataSetPackageDataValue = BasePackageDataValue & {
     category: Maybe<Id>;

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -45,7 +45,7 @@ export type EventsAPIResponse = Omit<EventsResponse, "instances"> & {
     events?: Event[];
 };
 
-type Coordinates = [number, number];
+type Coordinates = [longitude: number, latitude: number];
 
 export type Geometry =
     | {

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -15,6 +15,7 @@ export interface AggregatedDataValue {
     categoryOptionCombo?: string;
     attributeOptionCombo?: string;
     value: string;
+    comment?: string;
 }
 
 export interface Event {

--- a/src/domain/entities/DhisDataPackage.ts
+++ b/src/domain/entities/DhisDataPackage.ts
@@ -15,7 +15,6 @@ export interface AggregatedDataValue {
     categoryOptionCombo?: string;
     attributeOptionCombo?: string;
     value: string;
-    comment?: string;
 }
 
 export interface Event {

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -402,6 +402,7 @@ export type TemplateDataPackageData = {
         value: string | number | boolean;
         optionId: Maybe<string>;
         contentType: Maybe<ContentType>;
+        comment?: string;
     }[];
 };
 
@@ -467,6 +468,7 @@ export function templateFromDataPackage(dataPackage: DataPackage): TemplateDataP
                         value: dv.value,
                         category: dv.category,
                         optionId: dv.optionId,
+                        comment: dv.comment,
                         contentType: dv.contentType,
                     })),
                 })),
@@ -527,6 +529,7 @@ function mapFromProgramData(entry: ProgramPackageData): TemplateDataPackageData 
             value: dv.value,
             category: undefined,
             optionId: undefined,
+            comment: undefined,
             contentType: dv.contentType,
         })),
     };

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -424,6 +424,7 @@ export function templateToDataPackage(template: TemplateDataPackage): DataPackag
                         category: dv.category,
                         value: dv.value,
                         optionId: dv.optionId,
+                        comment: dv.comment,
                         contentType: dv.contentType,
                     })),
                 })),

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -401,6 +401,7 @@ export type TemplateDataPackageData = {
         category: Maybe<string>;
         value: string | number | boolean;
         optionId: Maybe<string>;
+        contentType: Maybe<ContentType>;
     }[];
 };
 
@@ -421,6 +422,8 @@ export function templateToDataPackage(template: TemplateDataPackage): DataPackag
                         dataElement: dv.dataElement,
                         category: dv.category,
                         value: dv.value,
+                        optionId: dv.optionId,
+                        contentType: dv.contentType,
                     })),
                 })),
             };
@@ -463,7 +466,8 @@ export function templateFromDataPackage(dataPackage: DataPackage): TemplateDataP
                         dataElement: dv.dataElement,
                         value: dv.value,
                         category: dv.category,
-                        optionId: undefined,
+                        optionId: dv.optionId,
+                        contentType: dv.contentType,
                     })),
                 })),
             };
@@ -500,6 +504,9 @@ function mapToProgramData(entry: TemplateDataPackageData): ProgramPackageData {
         dataValues: entry.dataValues.map(dv => ({
             dataElement: dv.dataElement,
             value: dv.value,
+            category: dv.category,
+            optionId: dv.optionId,
+            contentType: dv.contentType,
         })),
     };
 }
@@ -520,6 +527,7 @@ function mapFromProgramData(entry: ProgramPackageData): TemplateDataPackageData 
             value: dv.value,
             category: undefined,
             optionId: undefined,
+            contentType: dv.contentType,
         })),
     };
 }

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -378,7 +378,7 @@ type TemplateGenericDataPackage = BaseTemplateDataPackage & {
     type: "dataSets" | "programs";
 };
 
-type TemplateTrackerProgramPackage = BaseTemplateDataPackage & {
+export type TemplateTrackerProgramPackage = BaseTemplateDataPackage & {
     type: "trackerPrograms";
     trackedEntityInstances: TrackedEntityInstance[];
 };

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -442,7 +442,6 @@ export function templateToDataPackage(template: TemplateDataPackage): DataPackag
                     dataElement: dv.dataElement,
                     category: dv.category,
                     value: dv.value,
-                    comment: undefined,
                 })),
             })),
         };

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -18,6 +18,8 @@ import {
     SheetRef,
     TeiRowDataSource,
     Template,
+    TemplateDataPackage,
+    templateFromDataPackage,
     TrackerEventRowDataSource,
     TrackerRelationship,
     ValueRef,
@@ -45,18 +47,19 @@ export class ExcelBuilder {
             payload.type === "trackerPrograms"
                 ? await this.instanceRepository.getBuilderMetadata(payload.trackedEntityInstances)
                 : emptyBuilderMetadata;
+        const templatePayload = templateFromDataPackage(payload);
 
         for (const dataSource of dataSourceValues) {
             if (!dataSource.skipPopulate) {
                 switch (dataSource.type) {
                     case "cell":
-                        await this.fillCells(template, dataSource, payload);
+                        await this.fillCells(template, dataSource, templatePayload);
                         break;
                     case "row":
-                        await this.fillRows(template, dataSource, payload);
+                        await this.fillRows(template, dataSource, templatePayload);
                         break;
                     case "rowTei":
-                        await this.fillTeiRows(template, dataSource, payload);
+                        await this.fillTeiRows(template, dataSource, templatePayload);
                         break;
                     case "rowTrackedEvent":
                         await this.fillTrackerEventRows(
@@ -99,7 +102,7 @@ export class ExcelBuilder {
         });
     }
 
-    private async fillCells(template: Template, dataSource: CellDataSource, payload: DataPackage) {
+    private async fillCells(template: Template, dataSource: CellDataSource, payload: TemplateDataPackage) {
         const orgUnit = await this.readCellValue(template, dataSource.orgUnit);
         const dataElement = await this.readCellValue(template, dataSource.dataElement);
         const period = await this.readCellValue(template, dataSource.period);
@@ -120,7 +123,7 @@ export class ExcelBuilder {
         return removeCharacters(await this.excelRepository.readCell(template.id, ref));
     }
 
-    private async fillTeiRows(template: Template, dataSource: TeiRowDataSource, payload: DataPackage) {
+    private async fillTeiRows(template: Template, dataSource: TeiRowDataSource, payload: TemplateDataPackage) {
         let { rowStart } = dataSource.attributes;
         if (payload.type !== "trackerPrograms") return;
 
@@ -353,7 +356,7 @@ export class ExcelBuilder {
         }
     }
 
-    private async fillRows(template: Template, dataSource: RowDataSource, payload: DataPackage) {
+    private async fillRows(template: Template, dataSource: RowDataSource, payload: TemplateDataPackage) {
         let { rowStart } = dataSource.range;
 
         for (const { id, orgUnit, period, attribute, dataValues, coordinate } of payload.dataEntries) {

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -166,6 +166,7 @@ export class ExcelReader {
                         category: category ? this.formatValue(category) : undefined,
                         value: this.formatValue(value),
                         optionId: optionId ? removeCharacters(optionId) : undefined,
+
                         contentType: contentType,
                     },
                 ],

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -76,14 +76,14 @@ export class ExcelReader {
         const dataEntries = _(data)
             .groupBy(d =>
                 [
-                    d.group,
                     d.dataForm,
                     d.id,
-                    d.orgUnit,
                     d.period,
+                    d.orgUnit,
                     d.attribute,
                     d.trackedEntityInstance,
                     d.programStage,
+                    d.group,
                 ].join("@")
             )
             .map((items, key) => {

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -30,6 +30,7 @@ import {
 import { TrackedEntityInstance } from "../entities/TrackedEntityInstance";
 import { ExcelRepository, ExcelValue, ReadCellOptions } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
+import { Maybe } from "../../types/utils";
 
 const dateFormat = "YYYY-MM-DD";
 
@@ -507,7 +508,7 @@ export class ExcelReader {
     public async templateCustomization(
         template: Template,
         dataPackage: TemplateDataPackage
-    ): Promise<TemplateDataPackage | undefined> {
+    ): Promise<Maybe<TemplateDataPackage>> {
         if (template.type === "custom" && template.importCustomization) {
             return template.importCustomization(this.excelRepository, this.instanceRepository, {
                 dataPackage,

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -5,7 +5,7 @@ import moment from "moment";
 import { isDefined } from "../../utils";
 import { promiseMap } from "../../utils/promises";
 import { removeCharacters } from "../../utils/string";
-import { DataForm } from "../entities/DataForm";
+import { DataForm, dataFormTypeMap } from "../entities/DataForm";
 import { getGeometryFromString } from "../entities/Geometry";
 import { Relationship } from "../entities/Relationship";
 import {
@@ -42,7 +42,11 @@ export class ExcelReader {
         const dataFormType = await this.readCellValue(template, template.dataFormType);
         const dataSourceValues = await this.getDataSourceValues(template, dataSources);
 
-        if (dataFormType !== "dataSets" && dataFormType !== "programs" && dataFormType !== "trackerPrograms") {
+        if (
+            dataFormType !== dataFormTypeMap.dataSets &&
+            dataFormType !== dataFormTypeMap.programs &&
+            dataFormType !== dataFormTypeMap.trackerPrograms
+        ) {
             return undefined;
         }
 
@@ -105,9 +109,9 @@ export class ExcelReader {
             .compact()
             .value();
 
-        if (dataFormType === "trackerPrograms") {
+        if (dataFormType === dataFormTypeMap.trackerPrograms) {
             const trackedEntityInstances = this.addTeiRelationships(teis, relationships);
-            return { type: "trackerPrograms", dataEntries, trackedEntityInstances };
+            return { type: dataFormType, dataEntries, trackedEntityInstances };
         }
 
         return { type: dataFormType, dataEntries };

--- a/src/domain/helpers/ExcelReader.ts
+++ b/src/domain/helpers/ExcelReader.ts
@@ -137,13 +137,15 @@ export class ExcelReader {
             const dataFormId = await this.readCellValue(template, template.dataFormId, cell);
             if (!dataFormId) return undefined;
 
-            const category = await this.readCellValue(template, dataSource.categoryOption, cell);
+            const [category, attribute, eventId, latitude, longitude, contentType] = await Promise.all([
+                this.readCellValue(template, dataSource.categoryOption, cell),
+                this.readCellValue(template, dataSource.attribute, cell),
+                this.readCellValue(template, dataSource.eventId, cell),
+                this.readCellValue(template, dataSource.coordinates?.latitude, cell),
+                this.readCellValue(template, dataSource.coordinates?.longitude, cell),
+                this.excelRepository.getContentType(template.id, cell),
+            ]);
 
-            const attribute = await this.readCellValue(template, dataSource.attribute, cell);
-            const eventId = await this.readCellValue(template, dataSource.eventId, cell);
-
-            const latitude = await this.readCellValue(template, dataSource.coordinates?.latitude, cell);
-            const longitude = await this.readCellValue(template, dataSource.coordinates?.longitude, cell);
             const hasCoordinate = isDefined(latitude) && isDefined(longitude);
 
             return {
@@ -164,6 +166,7 @@ export class ExcelReader {
                         category: category ? this.formatValue(category) : undefined,
                         value: this.formatValue(value),
                         optionId: optionId ? removeCharacters(optionId) : undefined,
+                        contentType: contentType,
                     },
                 ],
             };
@@ -190,9 +193,12 @@ export class ExcelReader {
         const dataFormId = await this.readCellValue(template, template.dataFormId);
         if (!dataFormId) return [];
 
-        const category = await this.readCellValue(template, dataSource.categoryOption);
-        const attribute = await this.readCellValue(template, dataSource.attribute);
-        const eventId = await this.readCellValue(template, dataSource.eventId);
+        const [category, attribute, eventId, contentType] = await Promise.all([
+            this.readCellValue(template, dataSource.categoryOption),
+            this.readCellValue(template, dataSource.attribute),
+            this.readCellValue(template, dataSource.eventId),
+            this.excelRepository.getContentType(template.id, cell),
+        ]);
 
         return [
             {
@@ -211,6 +217,7 @@ export class ExcelReader {
                         category: category ? String(category) : undefined,
                         value: this.formatValue(value),
                         optionId: optionId ? removeCharacters(optionId) : undefined,
+                        contentType: contentType,
                     },
                 ],
             },

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -158,7 +158,7 @@ export class DownloadTemplateUseCase implements UseCase {
             type,
             id,
             populate,
-            dataPackage: dataPackage && templateFromDataPackage(dataPackage),
+            dataPackage: dataPackage ? templateFromDataPackage(dataPackage) : undefined,
             orgUnits,
             language: showLanguage ? language : undefined,
         });

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -11,7 +11,7 @@ import Settings from "../../webapp/logic/settings";
 import { getGeneratedTemplateId, SheetBuilder } from "../../webapp/logic/sheetBuilder";
 import { DataFormType } from "../entities/DataForm";
 import { Id, Ref } from "../entities/ReferenceObject";
-import { TemplateType } from "../entities/Template";
+import { templateFromDataPackage, TemplateType } from "../entities/Template";
 import { ExcelBuilder } from "../helpers/ExcelBuilder";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
@@ -158,7 +158,7 @@ export class DownloadTemplateUseCase implements UseCase {
             type,
             id,
             populate,
-            dataPackage,
+            dataPackage: dataPackage && templateFromDataPackage(dataPackage),
             orgUnits,
             language: showLanguage ? language : undefined,
         });

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -9,7 +9,7 @@ import { getExtensionFile, XLSX_EXTENSION } from "../../utils/files";
 import { promiseMap } from "../../utils/promises";
 import Settings from "../../webapp/logic/settings";
 import { getGeneratedTemplateId, SheetBuilder } from "../../webapp/logic/sheetBuilder";
-import { DataFormType } from "../entities/DataForm";
+import { DataFormType, dataFormTypeMap } from "../entities/DataForm";
 import { Id, Ref } from "../entities/ReferenceObject";
 import { templateFromDataPackage, TemplateType } from "../entities/Template";
 import { ExcelBuilder } from "../helpers/ExcelBuilder";
@@ -206,7 +206,7 @@ export class DownloadTemplateUseCase implements UseCase {
 }
 
 async function getElement(api: D2Api, type: DataFormType, id: string) {
-    const endpoint = type === "dataSets" ? "dataSets" : "programs";
+    const endpoint = type === dataFormTypeMap.dataSets ? "dataSets" : "programs";
     const fields = [
         "id",
         "displayName",
@@ -253,7 +253,7 @@ async function getElementMetadata({
     orgUnitShortName: boolean;
 }) {
     const elementMetadataMap = new Map();
-    const endpoint = element.type === "dataSets" ? "dataSets" : "programs";
+    const endpoint = element.type === dataFormTypeMap.dataSets ? "dataSets" : "programs";
     const elementMetadata = await api.get<ElementMetadata>(`/${endpoint}/${element.id}/metadata.json`).getData();
 
     const rawMetadata = await filterRawMetadata({ api, element, elementMetadata, orgUnitIds, startDate, endDate });

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -224,7 +224,7 @@ export class ImportTemplateUseCase implements UseCase {
         });
     }
 
-    private async readTemplate(template: Template, dataForm: DataForm): Promise<TemplateDataPackage | undefined> {
+    private async readTemplate(template: Template, dataForm: DataForm): Promise<Maybe<TemplateDataPackage>> {
         const reader = new ExcelReader(this.excelRepository, this.instanceRepository);
         const excelDataValues = await reader.readTemplate(template, dataForm);
         if (!excelDataValues) return undefined;
@@ -561,7 +561,7 @@ function getBooleanValue(item: TemplateDataPackageDataValue): Maybe<boolean> {
 const formatDhis2Value = (
     item: TemplateDataPackageDataValue,
     dataForm: DataForm
-): TemplateDataPackageDataValue | undefined => {
+): Maybe<TemplateDataPackageDataValue> => {
     const dataElement = dataForm.dataElements.find(({ id }) => item.dataElement === id);
     const booleanValue = getBooleanValue(item);
 

--- a/src/domain/usecases/ImportTemplateUseCase.ts
+++ b/src/domain/usecases/ImportTemplateUseCase.ts
@@ -17,6 +17,7 @@ import {
     TemplateDataPackageDataValue,
     templateFromDataPackage,
     templateToDataPackage,
+    TemplateTrackerProgramPackage,
 } from "../entities/Template";
 import { ExcelReader } from "../helpers/ExcelReader";
 import { ExcelRepository } from "../repositories/ExcelRepository";
@@ -26,7 +27,7 @@ import { FileRepository } from "../repositories/FileRepository";
 import { FileResource } from "../entities/FileResource";
 import { ImportSourceRepository } from "../repositories/ImportSourceRepository";
 import { AttributeValue, TrackedEntityInstance } from "../entities/TrackedEntityInstance";
-import { Maybe, Optional } from "../../types/utils";
+import { Maybe } from "../../types/utils";
 
 export type ImportTemplateError =
     | {
@@ -265,7 +266,7 @@ export class ImportTemplateUseCase implements UseCase {
         };
     }
 
-    private formatTrackedEntityInstances(dataPackage: TrackerProgramPackage, dataForm: DataForm) {
+    private formatTrackedEntityInstances(dataPackage: TemplateTrackerProgramPackage, dataForm: DataForm) {
         return {
             ...dataPackage,
             trackedEntityInstances: dataPackage.trackedEntityInstances.map(tei => {
@@ -601,7 +602,7 @@ function getOptionValue(originalValue: string, options?: DataOption[]): Maybe<Da
     return options.find(({ id, name }) => originalValue === id || originalValue === name);
 }
 
-function formatDataValue(item: DataPackageDataValue, dataForm: DataForm): Maybe<TemplateDataPackageDataValue> {
+function formatDataValue(item: TemplateDataPackageDataValue, dataForm: DataForm): Maybe<TemplateDataPackageDataValue> {
     const dataElement = dataForm.dataElements.find(({ id }) => item.dataElement === id);
     const booleanValue = getBooleanValue(item);
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -2,8 +2,6 @@ export type NonNullableValues<Obj> = { [K in keyof Obj]: NonNullable<Obj[K]> };
 
 export type Maybe<T> = T | undefined;
 
-export type MaybeNullable<T> = Maybe<T> | null;
-
 export type Dictionary<T> = Record<string, T>;
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,6 +1,8 @@
 export type NonNullableValues<Obj> = { [K in keyof Obj]: NonNullable<Obj[K]> };
 
-export type Maybe<T> = T | undefined | null;
+export type Maybe<T> = T | undefined;
+
+export type MaybeNullable<T> = Maybe<T> | null;
 
 export type Dictionary<T> = Record<string, T>;
 

--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -8,7 +8,6 @@ import moment from "moment";
 import React, { useCallback, useEffect, useState } from "react";
 import Dropzone from "react-dropzone";
 import { DataForm, DataFormType } from "../../../domain/entities/DataForm";
-import { DataPackage } from "../../../domain/entities/DataPackage";
 import { SynchronizationResult } from "../../../domain/entities/SynchronizationResult";
 import { ImportTemplateUseCaseParams } from "../../../domain/usecases/ImportTemplateUseCase";
 import i18n from "../../../utils/i18n";
@@ -17,6 +16,7 @@ import SyncSummary from "../../components/sync-summary/SyncSummary";
 import { useAppContext } from "../../contexts/app-context";
 import { orgUnitListParams } from "../../utils/template";
 import { RouteComponentProps } from "../Router";
+import { TemplateDataPackage, templateToDataPackage } from "../../../domain/entities/Template";
 
 interface ImportState {
     dataForm: DataForm;
@@ -272,8 +272,8 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
         });
     };
 
-    const downloadInvalidOrganisations = (dataPackage: DataPackage) => {
-        const object = compositionRoot.form.convertDataPackage(dataPackage);
+    const downloadInvalidOrganisations = (dataPackage: TemplateDataPackage) => {
+        const object = compositionRoot.form.convertDataPackage(templateToDataPackage(dataPackage));
         const json = JSON.stringify(object, null, 4);
         const blob = new Blob([json], { type: "application/json" });
         const date = moment().format("YYYYMMDDHHmm");


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #86993u0x8 [Make TEI ID available in Program Stages tabs by default](https://app.clickup.com/t/86993u0x8)

### :memo: Implementation
- refactored DataPackage - discriminated unions
- DataPackage was heavily used in `ExcelBuilder` and `ExcelReader`. To avoid extending the scope to import/export flows, `Template` models were created.  
- removed unused `comment` prop from DataPackage type "dataSets" 

Note: bug introduced in #327 where `trackedEntityInstance` was renamed only during mapping. It was an optional prop so there were no complaints from typescript.

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/cf0c25e2-ab4d-4b00-ab89-80289bfcaeff


### :bookmark_tabs: Others
tested: import/export tracker programs and datasets