### PR TITLE
read program stage id ref as a formula instead plain value

### DIFF
--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -116,8 +116,12 @@ export class ExcelBuilder {
         }
     }
 
-    private async readCellValue(template: Template, ref?: CellRef | ValueRef): Promise<ExcelValue> {
-        return removeCharacters(await this.excelRepository.readCell(template.id, ref));
+    private async readCellValue(
+        template: Template,
+        ref?: CellRef | ValueRef,
+        options: { isFormula: boolean } = { isFormula: false }
+    ): Promise<ExcelValue> {
+        return removeCharacters(await this.excelRepository.readCell(template.id, ref, { formula: options.isFormula }));
     }
 
     private async fillTeiRows(template: Template, dataSource: TeiRowDataSource, payload: DataPackage) {
@@ -270,7 +274,9 @@ export class ExcelBuilder {
 
         const dataElementIdsSet = new Set(dataElementIds);
 
-        const dataSourceProgramStageId = await this.readCellValue(template, dataSource.programStage);
+        const dataSourceProgramStageId = await this.readCellValue(template, dataSource.programStage, {
+            isFormula: true,
+        });
         for (const dataEntry of payload.dataEntries) {
             const { id, period, dataValues, trackedEntityInstance, attribute: cocId, programStage } = dataEntry;
             const someDataElementPresentInSheet = _(dataValues).some(dv => dataElementIdsSet.has(dv.dataElement));


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/86996g6dx

### :memo: Implementation

- [x] Create custom template for PSHM program tracker (template and data source are attached in issue).
- [x] When the library reads the program stage ref cell it tries to get 2 values: formula and value. Then the final value to use depends on whether we're reading the cell as formula or value.

If we have an autogenerated template like this:

![image](https://github.com/user-attachments/assets/2f038f60-35bc-42c5-9d29-5105edc29181)

We get: `formulaValue = VOv5fjfR80N` and `value = undefined`. The library sets the id to `VOv5fjfR80N` because `value` is undefined.

But for some reason when we have a custom template (created by hand) the values we get are:

`formulaValue = VOv5fjfR80N` and `value = custom_stage_1` <- not undefined anymore

and since this particular column was not read as a "cell formula" the library sets the id to `custom_stage_1` and as a result no events are being populated. 

With this change this formula is always read as a "formula" to avoid this behaviour.

- [ ] TODO: Support for optionSets with multiple values

### :fire: Notes for the reviewer

### :art: Screenshots

### :bookmark_tabs: Others

#86996g6dx