### PR TITLE
Sort categoryOptionCombo name by categoryCombo.category

### DIFF
--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -1094,13 +1094,7 @@ export class SheetBuilder {
             translations.find(({ property }: any) => property === "DESCRIPTION") ?? {};
 
         if (item?.type === "categoryOptionCombos" && name === defaultName) {
-            const options = item?.categoryOptions?.map(({ id }: any) => {
-                const element = elementMetadata.get(id);
-                const { name } = this.translate(element);
-                return name;
-            });
-
-            return { name: options.join(", "), description };
+            return { name: this.buildCategoryOptionComboName(item), description };
         } else if (
             this.builder.useCodesForMetadata &&
             item?.code &&
@@ -1109,6 +1103,36 @@ export class SheetBuilder {
             return { name: item.code, description };
         } else {
             return { name: selectedName ? item.displayShortName : name, description };
+        }
+    }
+
+    private buildCategoryOptionComboName(item: any): string {
+        const { elementMetadata } = this.builder;
+        const itemCategoryOptions = item?.categoryOptions?.map(({ id }: any) => id);
+
+        if (!itemCategoryOptions) return "";
+        else if (itemCategoryOptions.length > 1) {
+            const categoryCombo = elementMetadata.get(item.categoryCombo?.id);
+            const orderedCategories = categoryCombo?.categories?.map(({ id }: any) => {
+                const category = elementMetadata.get(id);
+                return {
+                    ...category,
+                    options: category?.categoryOptions.map(({ id }: any) => id),
+                };
+            });
+
+            const categoryToOption = orderedCategories.map((category: any) => {
+                const optionId = category.options.find((id: any) => itemCategoryOptions.includes(id));
+                const element = elementMetadata.get(optionId);
+                const { name } = this.translate(element);
+                return name;
+            });
+
+            return categoryToOption.join(", ");
+        } else {
+            const option = elementMetadata.get(itemCategoryOptions[0]);
+            const { name } = this.translate(option);
+            return name;
         }
     }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #86955t567 [Improve ordering of category options in category option combos](https://app.clickup.com/t/86955t567)


* **d2-api**: Requires #
* **d2-ui-components**: Requires #

### :memo: Implementation
- build categoryOptionCombo name based on categoryCombo.category order

Details:
- we were building the name based on the order of `categoryOptionCombo.categoryOptions` where the order is not preserved leading inconsistent names.

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others
