### PR TITLE
Feature/support functions

### DIFF
--- a/.githooks/dep-check
+++ b/.githooks/dep-check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 changed () {
   git diff --name-only HEAD@{1} HEAD | grep "^$1" > /dev/null 2>&1

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -9,13 +9,23 @@ import _ from "lodash";
 import moment from "moment";
 import { CellDataValidation } from "../domain/entities/CellDataValidation";
 import { Sheet } from "../domain/entities/Sheet";
-import { CellRef, ColumnRef, Range, RangeRef, RowRef, SheetRef, ValueRef } from "../domain/entities/Template";
+import {
+    CellRef,
+    ColumnRef,
+    ContentType,
+    Range,
+    RangeRef,
+    RowRef,
+    SheetRef,
+    ValueRef,
+} from "../domain/entities/Template";
 import { ThemeStyle } from "../domain/entities/Theme";
 import { ExcelRepository, ExcelValue, LoadOptions, ReadCellOptions } from "../domain/repositories/ExcelRepository";
 import i18n from "../utils/i18n";
 import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
 import { removeCharacters } from "../utils/string";
+import { Optional } from "../types/utils";
 
 export class ExcelPopulateRepository extends ExcelRepository {
     private workbooks: Record<string, ExcelWorkbook> = {};
@@ -129,6 +139,25 @@ export class ExcelPopulateRepository extends ExcelRepository {
         return this.readCellValue(workbook, cellRef, options?.formula);
     }
 
+    public async getContentType(id: string, cellRef?: CellRef | ValueRef): Promise<Optional<ContentType>> {
+        if (!cellRef) return undefined;
+        if (cellRef.type === "value") return "raw";
+
+        const workbook = await this.getWorkbook(id);
+        const { cell } = this.getDestination(workbook, cellRef);
+
+        const formula = cell.formula();
+
+        if (!formula) {
+            return "raw";
+        } else if (formula.includes("(") && formula.includes(")")) {
+            //using excel specific functions
+            return "function";
+        } else {
+            return "formula";
+        }
+    }
+
     public async getConstants(id: string): Promise<Record<string, string>> {
         const workbook = await this.getWorkbook(id);
         const keys = (workbook as any).definedName() as string[];
@@ -157,21 +186,29 @@ export class ExcelPopulateRepository extends ExcelRepository {
         });
     }
 
+    private getDestination(workbook: Workbook, cellRef: CellRef): { cell: XLSX.Cell; sheet: XLSX.Sheet } {
+        const mergedCells = this.listMergedCells(workbook, cellRef.sheet);
+        const sheet = workbook.sheet(cellRef.sheet);
+        const cell = sheet.cell(cellRef.ref);
+        const { startCell: destination = cell } = mergedCells.find(range => range.hasCell(cell)) ?? {};
+        return {
+            cell: destination,
+            sheet,
+        };
+    }
+
     private async readCellValue(
         workbook: Workbook,
         cellRef: CellRef,
         formula = false
     ): Promise<ExcelValue | undefined> {
-        const mergedCells = this.listMergedCells(workbook, cellRef.sheet);
-        const sheet = workbook.sheet(cellRef.sheet);
-        const cell = sheet.cell(cellRef.ref);
-        const { startCell: destination = cell } = mergedCells.find(range => range.hasCell(cell)) ?? {};
+        const { cell: destination, sheet } = this.getDestination(workbook, cellRef);
 
         const getFormulaValue = () => getFormulaWithValidation(workbook, sheet as SheetWithValidations, destination);
 
         const formulaValue = getFormulaValue();
         const textValue = getValue(destination);
-        const value = formula ? formulaValue : textValue ?? formulaValue;
+        const value = formula ? formulaValue : this.resolveNA(textValue ?? "", formulaValue ?? "");
 
         if (value instanceof FormulaError) return "";
 
@@ -184,6 +221,17 @@ export class ExcelPopulateRepository extends ExcelRepository {
         }
 
         return value;
+    }
+
+    // #N/A is a common result of a formula that does not find a value
+    // return a blank string when formula results to #N/A
+    // -----
+    // can be used as a workaround:
+    // formulas that result to blank cells store the raw formula in the value
+    // use #N/A as default value instead of blank
+    private resolveNA(value: ExcelValue, formula: ExcelValue): ExcelValue {
+        if (value === "#N/A") return "";
+        return value ?? formula;
     }
 
     public async getCellsInRange(id: string, range: Range): Promise<CellRef[]> {

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -136,6 +136,7 @@ export class InstanceDhisRepository implements InstanceRepository {
                     id: trackedEntityAttribute.id,
                     name: trackedEntityAttribute.name,
                     valueType: trackedEntityAttribute.valueType,
+                    options: trackedEntityAttribute.optionSet?.options,
                 })),
                 trackedEntityType: getTrackedEntityTypeFromApi(trackedEntityType),
             })
@@ -758,7 +759,7 @@ const dataElementFields = {
     name: true,
     valueType: true,
     categoryCombo: { categoryOptionCombos: { id: true, name: true } },
-    optionSet: { id: true, options: { id: true, code: true } },
+    optionSet: { id: true, options: { id: true, code: true, name: true } },
 } as const;
 
 const dataSetFields = {
@@ -783,7 +784,14 @@ const programFields = {
         programStageDataElements: { dataElement: dataElementFields },
         repeatable: true,
     },
-    programTrackedEntityAttributes: { trackedEntityAttribute: { id: true, name: true, valueType: true } },
+    programTrackedEntityAttributes: {
+        trackedEntityAttribute: {
+            id: true,
+            name: true,
+            valueType: true,
+            optionSet: { id: true, options: { id: true, code: true, name: true } },
+        },
+    },
     access: true,
     programType: true,
     trackedEntityType: { id: true, featureType: true },

--- a/src/domain/entities/DataForm.ts
+++ b/src/domain/entities/DataForm.ts
@@ -40,6 +40,7 @@ export interface DataForm {
 
 export interface TrackedEntityAttributeType extends NamedRef {
     valueType: DataElementType | undefined;
+    options: Array<DataOption>;
 }
 
 export interface TrackedEntityType {
@@ -54,8 +55,10 @@ export interface DataElement {
     name: string;
     valueType: DataElementType;
     categoryOptionCombos?: Array<{ id: Id; name: string }>;
-    options: Array<{ id: Id; code: string }>;
+    options: Array<DataOption>;
 }
+
+export type DataOption = { id: Id; code: string; name: string };
 
 export type DataElementType =
     | "TEXT"

--- a/src/domain/entities/DataPackage.ts
+++ b/src/domain/entities/DataPackage.ts
@@ -1,6 +1,7 @@
 import { DataFormType } from "./DataForm";
 import { Id } from "./ReferenceObject";
 import { TrackedEntityInstance } from "./TrackedEntityInstance";
+import { ContentType } from "./Template";
 
 export type DataPackage = GenericProgramPackage | TrackerProgramPackage;
 export type DataPackageValue = string | number | boolean;
@@ -41,4 +42,5 @@ export interface DataPackageDataValue {
     value: DataPackageValue;
     optionId?: Id;
     comment?: string;
+    contentType?: ContentType;
 }

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -244,6 +244,8 @@ interface DataFormRef {
     id: Maybe<string>;
 }
 
+export type ContentType = "raw" | "formula" | "function";
+
 export function getDataFormRef(template: BaseTemplate): DataFormRef {
     const { dataFormType, dataFormId } = template;
 

--- a/src/domain/entities/TrackedEntityInstance.ts
+++ b/src/domain/entities/TrackedEntityInstance.ts
@@ -4,6 +4,7 @@ import { Geometry } from "./Geometry";
 import { Id, Ref } from "./ReferenceObject";
 import { Relationship } from "./Relationship";
 import { D2TrackerAttribute } from "./TrackedEntity";
+import { ContentType } from "./Template";
 
 export interface TrackedEntityInstance {
     program: Ref;
@@ -30,6 +31,7 @@ export interface AttributeValue {
     attribute: Attribute;
     value: string;
     optionId?: Id;
+    contentType?: ContentType;
 }
 
 export interface Program {

--- a/src/domain/repositories/ExcelRepository.ts
+++ b/src/domain/repositories/ExcelRepository.ts
@@ -1,6 +1,6 @@
 import { CellDataValidation } from "../entities/CellDataValidation";
 import { Sheet } from "../entities/Sheet";
-import { CellRef, ColumnRef, Range, RangeRef, RowRef, SheetRef, ValueRef } from "../entities/Template";
+import { CellRef, ColumnRef, ContentType, Range, RangeRef, RowRef, SheetRef, ValueRef } from "../entities/Template";
 import { ThemeStyle } from "../entities/Theme";
 
 export type LoadOptions = WebLoadOptions | FileLoadOptions | FileBase64LoadOptions;
@@ -38,6 +38,11 @@ export abstract class ExcelRepository {
         cellRef?: CellRef | ValueRef,
         options?: ReadCellOptions
     ): Promise<ExcelValue | undefined>;
+    public abstract getContentType(
+        id: string,
+        cellRef?: CellRef | ValueRef,
+        options?: ReadCellOptions
+    ): Promise<ContentType | undefined>;
     public abstract getCellsInRange(id: string, range: Range): Promise<CellRef[]>;
     public abstract addPicture(id: string, location: SheetRef, file: File): Promise<void>;
     public abstract styleCell(id: string, source: SheetRef, style: ThemeStyle): Promise<void>;

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -77,7 +77,7 @@ export function initializeMockServer() {
     mock.onGet("/dataSets", {
         params: {
             paging: false,
-            fields: "access,attributeValues[attribute[code],value],dataSetElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id]],valueType]],displayName,id,name,periodType,sections[dataElements[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id]],valueType],id,name]",
+            fields: "access,attributeValues[attribute[code],value],dataSetElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id,name]],valueType]],displayName,id,name,periodType,sections[dataElements[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id,name]],valueType],id,name]",
             filter: [],
         },
     }).reply(200, {
@@ -111,7 +111,7 @@ export function initializeMockServer() {
     mock.onGet("/programs", {
         params: {
             paging: false,
-            fields: "access,attributeValues[attribute[code],value],displayName,id,name,programStages[id,name,programStageDataElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id]],valueType]],repeatable],programTrackedEntityAttributes[trackedEntityAttribute[id,name,valueType]],programType,trackedEntityType[featureType,id]",
+            fields: "access,attributeValues[attribute[code],value],displayName,id,name,programStages[id,name,programStageDataElements[dataElement[categoryCombo[categoryOptionCombos[id,name]],formName,id,name,optionSet[id,options[code,id,name]],valueType]],repeatable],programTrackedEntityAttributes[trackedEntityAttribute[id,name,optionSet[id,options[code,id,name]],valueType]],programType,trackedEntityType[featureType,id]",
             filter: [],
         },
     }).reply(200, {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,6 +1,8 @@
 export type NonNullableValues<Obj> = { [K in keyof Obj]: NonNullable<Obj[K]> };
 
-export type Maybe<T> = T | undefined | null;
+export type Optional<T> = T | undefined;
+
+export type Maybe<T> = Optional<T> | null;
 
 export type Dictionary<T> = Record<string, T>;
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,7 @@
 export function removeCharacters(value: unknown): string {
     return value === undefined ? "" : String(value).replace(/[^a-zA-Z0-9.]/g, "");
 }
+
+export function isString(value: unknown): value is string {
+    return typeof value === "string";
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #8699wax2k [Display subnational depending on country](https://app.clickup.com/t/8699wax2k)

### :memo: Implementation
To support excel functions, main changes that were required was:
1. For dataValues - to be able to get option selected based on name
2. For TEI attributes - use evaluated value instead of optionId (current implementation defaults to optionId if an option is not found)
 
Implementation details:
 1. for dataValues
- Include name in optionSet.options
- added mapping of optionset values based on name.

2. for TEI attributes
- include optionSet.options when fetching trackerProgram FormData
- fetch option based on name, similar to `#1`
    - NOTE: I initially put this step in `Dhis2TrackedEntityInstance.getValue` but there are potential issues here since options is saved as a single array and `option.name` is not unique. A code for a different optionSet can be mistakenly selected which will make the import fail.
- To overwrite the default behavior of defaulting to optionId, `contentType` is used to force the use of evaluated function.
   

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others
