### PR TITLE
Feature/data processing rules

### DIFF
--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -150,6 +150,21 @@ export interface Range {
     columnEnd?: string;
 }
 
+type BaseDataProcessingRule = {
+    type: "coalesce" | "skip";
+    condition: "onExport" | "onImport";
+    description?: string;
+};
+
+export type DataProcessingRuleCoalesce = BaseDataProcessingRule & {
+    type: "coalesce";
+    condition: "onExport";
+    destination: ColumnRef;
+    targetIds: Id[]; // attribute or data element id
+};
+
+type DataProcessingRule = DataProcessingRuleCoalesce;
+
 interface BaseDataSource {
     type: DataSourceType;
     skipPopulate?: boolean;
@@ -190,6 +205,7 @@ export interface TrackerEventRowDataSource {
     dataElements: Range;
     sortBy?: string;
     onlyLastEvent?: boolean;
+    dataElementProcessingRules?: DataProcessingRule[];
 }
 
 export interface RowDataSource extends BaseDataSource {
@@ -222,6 +238,7 @@ export interface TeiRowDataSource {
     multiTextDelimiter?: string;
     sortBy?: string;
     skipTeisWithoutEvents?: boolean;
+    attributeDataProcessingRules?: DataProcessingRule[];
 }
 
 export interface ColumnDataSource extends BaseDataSource {
@@ -388,6 +405,14 @@ export type TemplateTrackerProgramPackage = BaseTemplateDataPackage & {
     trackedEntityInstances: TrackedEntityInstance[];
 };
 
+export type TemplateDataValue = {
+    dataElement: string;
+    category: Maybe<string>;
+    value: string | number | boolean;
+    optionId: Maybe<string>;
+    contentType: Maybe<ContentType>;
+    comment?: string;
+};
 export type TemplateDataPackageData = {
     group: number | Maybe<string>;
     dataForm: string;
@@ -401,14 +426,7 @@ export type TemplateDataPackageData = {
     }>;
     trackedEntityInstance: Maybe<string>;
     programStage: Maybe<string>;
-    dataValues: {
-        dataElement: string;
-        category: Maybe<string>;
-        value: string | number | boolean;
-        optionId: Maybe<string>;
-        contentType: Maybe<ContentType>;
-        comment?: string;
-    }[];
+    dataValues: TemplateDataValue[];
 };
 
 export function templateToDataPackage(template: TemplateDataPackage): DataPackage {
@@ -573,4 +591,8 @@ function geometryToCoordinate(geometry?: Geometry): Maybe<TemplateDataPackageDat
         default:
             return undefined;
     }
+}
+
+export function isDataProcessingRuleCoalesce(rule: DataProcessingRule): rule is DataProcessingRuleCoalesce {
+    return rule.type === "coalesce";
 }

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -151,8 +151,8 @@ export interface Range {
 }
 
 type BaseDataProcessingRule = {
-    type: "coalesce" | "skip";
-    condition: "onExport" | "onImport";
+    type: "coalesce";
+    condition: "onExport";
     description?: string;
 };
 

--- a/src/domain/helpers/DataProcessingService.ts
+++ b/src/domain/helpers/DataProcessingService.ts
@@ -2,7 +2,7 @@ import { CellRef, DataProcessingRuleCoalesce, TemplateDataValue } from "../entit
 import { Id } from "../entities/ReferenceObject";
 import _ from "lodash";
 
-type DataToProcess = {
+export type DataToProcess = {
     cell: CellRef;
     id: Id; //data element or attribute id
     value: TemplateDataValue["value"];
@@ -30,13 +30,13 @@ export class DataProcessingService {
 
             const firstValidDetail = validDetails.find(detail => Boolean(detail.value) || Boolean(detail.optionId));
 
-            if (firstValidDetail) {
+            if (!firstValidDetail) return undefined;
+            else {
                 return {
                     ...firstValidDetail,
                     cell: this.replaceColumn(firstValidDetail.cell, rule.destination.ref),
                 };
             }
-            return undefined;
         });
 
         return [...otherDataElements, ..._.compact(coalescedEntries)];

--- a/src/domain/helpers/DataProcessingService.ts
+++ b/src/domain/helpers/DataProcessingService.ts
@@ -31,12 +31,10 @@ export class DataProcessingService {
             const firstValidDetail = validDetails.find(detail => Boolean(detail.value) || Boolean(detail.optionId));
 
             if (!firstValidDetail) return undefined;
-            else {
-                return {
-                    ...firstValidDetail,
-                    cell: this.replaceColumn(firstValidDetail.cell, rule.destination.ref),
-                };
-            }
+            return {
+                ...firstValidDetail,
+                cell: this.replaceColumn(firstValidDetail.cell, rule.destination.ref),
+            };
         });
 
         return [...otherDataElements, ..._.compact(coalescedEntries)];

--- a/src/domain/helpers/DataProcessingService.ts
+++ b/src/domain/helpers/DataProcessingService.ts
@@ -1,0 +1,52 @@
+import { CellRef, DataProcessingRuleCoalesce, TemplateDataValue } from "../entities/Template";
+import { Id } from "../entities/ReferenceObject";
+import _ from "lodash";
+
+type DataToProcess = {
+    cell: CellRef;
+    id: Id; //data element or attribute id
+    value: TemplateDataValue["value"];
+    optionId?: TemplateDataValue["optionId"];
+};
+
+export class DataProcessingService {
+    static coalesceValues(props: {
+        dataDetails: DataToProcess[];
+        dataProcessingRules?: DataProcessingRuleCoalesce[];
+    }): DataToProcess[] {
+        const { dataProcessingRules, dataDetails } = props;
+
+        if (!dataProcessingRules || dataProcessingRules.length < 1) return dataDetails;
+
+        const dataElementIdsToCoalesce = new Set(dataProcessingRules.flatMap(rule => rule.targetIds));
+        const [dataElementToCoalesce, otherDataElements] = _.partition(dataDetails, details =>
+            dataElementIdsToCoalesce.has(details.id)
+        );
+
+        const coalescedEntries = dataProcessingRules.map(rule => {
+            const validDetails = _(rule.targetIds)
+                .map(id => dataElementToCoalesce.find(detail => detail.id === id))
+                .compact();
+
+            const firstValidDetail = validDetails.find(detail => Boolean(detail.value) || Boolean(detail.optionId));
+
+            if (firstValidDetail) {
+                return {
+                    ...firstValidDetail,
+                    cell: this.replaceColumn(firstValidDetail.cell, rule.destination.ref),
+                };
+            }
+            return undefined;
+        });
+
+        return [...otherDataElements, ..._.compact(coalescedEntries)];
+    }
+
+    private static replaceColumn(cellRef: CellRef, newColumn: string): CellRef {
+        const rowNumber = cellRef.ref.replace(/[A-Z]+/, "");
+        return {
+            ...cellRef,
+            ref: `${newColumn}${rowNumber}`,
+        };
+    }
+}

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -382,6 +382,7 @@ export class ExcelBuilder {
                 dataProcessingRules: coalesceDataProcessRules,
             });
 
+            //TODO extract "_<VALUE" as a helper since it's used multiple times in multiple files
             await Promise.all(
                 dataElementDetails.map(({ cell, optionId, value }) =>
                     this.excelRepository.writeCell(template.id, cell, optionId ? `_${optionId}` : value)

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -12,6 +12,7 @@ import {
     DataSource,
     DataSourceValue,
     DownloadCustomizationOptions,
+    isDataProcessingRuleCoalesce,
     RowDataSource,
     setDataEntrySheet,
     setSheet,
@@ -33,6 +34,7 @@ import { BuilderMetadata, emptyBuilderMetadata, InstanceRepository } from "../re
 import Settings from "../../webapp/logic/settings";
 import { ModulesRepositories } from "../repositories/ModulesRepositories";
 import { Maybe } from "../../types/utils";
+import { DataProcessingService } from "./DataProcessingService";
 
 const dateFormatPattern = "yyyy-MM-dd";
 
@@ -182,34 +184,51 @@ export class ExcelBuilder {
                     format(new Date(enrollment.occurredAt), dateFormatPattern)
                 );
 
-            for (const cell of cells) {
-                const attributeIdCell = await this.excelRepository.findRelativeCell(
-                    template.id,
-                    dataSource.attributeId,
-                    cell
-                );
+            const allAttributeDetails = await Promise.all(
+                cells.map(async cell => {
+                    const attributeIdCell = await this.excelRepository.findRelativeCell(
+                        template.id,
+                        dataSource.attributeId,
+                        cell
+                    );
 
-                const attributeId = attributeIdCell
-                    ? removeCharacters(
-                          await this.excelRepository.readCell(template.id, attributeIdCell, {
-                              formula: true,
-                          })
-                      )
-                    : undefined;
+                    const attributeId = attributeIdCell
+                        ? removeCharacters(
+                              await this.excelRepository.readCell(template.id, attributeIdCell, {
+                                  formula: true,
+                              })
+                          )
+                        : undefined;
+                    if (!attributeId || !cell) return undefined;
 
-                const attributeValue = tei.attributeValues.find(av => av.attribute.id === attributeId);
+                    const attributeValue = tei.attributeValues.find(av => av.attribute.id === attributeId);
+                    const isMultiText = attributeValue?.attribute.valueType === "MULTI_TEXT";
+                    const value =
+                        isMultiText && dataSource.multiTextDelimiter
+                            ? this.getMultiTextValue(attributeValue, dataSource.multiTextDelimiter)
+                            : this.getValueFromAttribute(attributeValue);
 
-                const isMultiText = attributeValue?.attribute.valueType === "MULTI_TEXT";
+                    return value
+                        ? {
+                              id: attributeId,
+                              cell,
+                              value,
+                          }
+                        : undefined;
+                })
+            );
 
-                const value =
-                    isMultiText && dataSource.multiTextDelimiter
-                        ? this.getMultiTextValue(attributeValue, dataSource.multiTextDelimiter)
-                        : this.getValueFromAttribute(attributeValue);
+            const coalesceDataProcessRules =
+                dataSource.attributeDataProcessingRules?.filter(isDataProcessingRuleCoalesce);
 
-                if (value) {
-                    this.excelRepository.writeCell(template.id, cell, value);
-                }
-            }
+            const attributeDetails = DataProcessingService.coalesceValues({
+                dataDetails: _.compact(allAttributeDetails),
+                dataProcessingRules: coalesceDataProcessRules,
+            });
+
+            await Promise.all(
+                attributeDetails.map(({ cell, value }) => this.excelRepository.writeCell(template.id, cell, value))
+            );
 
             rowStart += 1;
         }
@@ -337,14 +356,38 @@ export class ExcelBuilder {
             const dateCell = await this.excelRepository.findRelativeCell(template.id, dataSource.date, cells[0]);
             if (dateCell) await this.excelRepository.writeCell(template.id, dateCell, period);
 
-            for (const [dataElementId, cell] of _.zip(dataElementIds, cells)) {
-                if (!dataElementId || !cell) continue;
-                const { value } = dataValues.find(dv => dv.dataElement === dataElementId) ?? {};
-                if (value) {
-                    const optionId = metadata.options[value.toString()]?.id;
-                    await this.excelRepository.writeCell(template.id, cell, optionId ? `_${optionId}` : value);
-                }
-            }
+            const allDataElementDetails = _.compact(
+                _.zip(dataElementIds, cells).map(([dataElementId, cell]) => {
+                    if (!dataElementId || !cell) return undefined;
+                    const { value } = dataValues.find(dv => dv.dataElement === dataElementId) ?? {};
+                    if (value) {
+                        const optionId = metadata.options[value.toString()]?.id;
+                        return {
+                            id: dataElementId,
+                            cell,
+                            value,
+                            optionId,
+                        };
+                    } else {
+                        return undefined;
+                    }
+                })
+            );
+
+            const coalesceDataProcessRules =
+                dataSource.dataElementProcessingRules?.filter(isDataProcessingRuleCoalesce);
+
+            const dataElementDetails = DataProcessingService.coalesceValues({
+                dataDetails: allDataElementDetails,
+                dataProcessingRules: coalesceDataProcessRules,
+            });
+
+            await Promise.all(
+                dataElementDetails.map(({ cell, optionId, value }) =>
+                    this.excelRepository.writeCell(template.id, cell, optionId ? `_${optionId}` : value)
+                )
+            );
+
             rowStart += 1;
         }
 

--- a/src/domain/helpers/ExcelBuilder.ts
+++ b/src/domain/helpers/ExcelBuilder.ts
@@ -34,7 +34,7 @@ import { BuilderMetadata, emptyBuilderMetadata, InstanceRepository } from "../re
 import Settings from "../../webapp/logic/settings";
 import { ModulesRepositories } from "../repositories/ModulesRepositories";
 import { Maybe } from "../../types/utils";
-import { DataProcessingService } from "./DataProcessingService";
+import { DataProcessingService, DataToProcess } from "./DataProcessingService";
 
 const dateFormatPattern = "yyyy-MM-dd";
 
@@ -356,8 +356,8 @@ export class ExcelBuilder {
             const dateCell = await this.excelRepository.findRelativeCell(template.id, dataSource.date, cells[0]);
             if (dateCell) await this.excelRepository.writeCell(template.id, dateCell, period);
 
-            const allDataElementDetails = _.compact(
-                _.zip(dataElementIds, cells).map(([dataElementId, cell]) => {
+            const dataElementsToProcess = _.compact(
+                _.zip(dataElementIds, cells).map(([dataElementId, cell]): Maybe<DataToProcess> => {
                     if (!dataElementId || !cell) return undefined;
                     const { value } = dataValues.find(dv => dv.dataElement === dataElementId) ?? {};
                     if (value) {
@@ -378,7 +378,7 @@ export class ExcelBuilder {
                 dataSource.dataElementProcessingRules?.filter(isDataProcessingRuleCoalesce);
 
             const dataElementDetails = DataProcessingService.coalesceValues({
-                dataDetails: allDataElementDetails,
+                dataDetails: dataElementsToProcess,
                 dataProcessingRules: coalesceDataProcessRules,
             });
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #869ac4utq [Create a coalesce function on export](https://app.clickup.com/t/869ac4utq)

### :memo: Implementation
- Add data processing rule to perform coalesce. Only supported in tracker programs TEI Attributes and Event DataElements.
- given an array of ids (TEA/DE), coalesce the values and save in a specified column

**more details on usage in PHSM:** templates available in the specified clickup task
- **used for subnationals**. Each org unit has it's own data element to store the org unit specific subnational. These subnational DEs are coalesced upon export and saved in a column (colAD) not tied to a specific DE. Actual subnational DE columns contain a formula that copies the value of the (colAD). 

sample data source configuration:
```
"dataElementProcessingRules": [
	{
                "description": "subnationals",
		"type": "coalesce",
		"condition": "onExport",
		"destination": {
			"type": "column",
			"ref": "AD",
			"sheet": "TEI Instances"
		},
		"targetIds": [....]
	}
]
```

- **used to redirect where policy id is exported**. Policy id column contains a formula to build the policy id based on a specific format. To avoid overwriting the formula, policy id is exported to a different column.

sample data source configuration:

```
"attributeDataProcessingRules": [
	{
		"description": "To avoid overwriting formula in attribute column for policy id (colK)",
		"type": "coalesce",
		"condition": "onExport",
		"destination": {
			"type": "column",
			"ref": "N",
			"sheet": "TEI Instances"
		},
		"targetIds": ["b5LxOt3GHOZ"]
	}
]
```

Subnational
<img width="1067" height="384" alt="image" src="https://github.com/user-attachments/assets/31430858-0cc6-41f2-942a-3a5a0bc905d6" />


### :fire: Notes for the reviewer

### :art: Screenshots

### :bookmark_tabs: Others
