### PR TITLE
improve error message if validation report is not included

### DIFF
--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -3,6 +3,9 @@ import { SynchronizationResult, SynchronizationStats } from "../domain/entities/
 import i18n from "../utils/i18n";
 import { D2Api, Id } from "../types/d2-api";
 import { Ref } from "../domain/entities/ReferenceObject";
+import { ErrorMessage } from "../domain/entities/SynchronizationResult";
+import { promiseMap } from "../utils/promises";
+import { UidErrorMessage } from "./UidErrorMessage";
 
 export type Status = "OK" | "ERROR";
 
@@ -52,13 +55,14 @@ const defaultStats = {
     total: 0,
 };
 
-export function processImportResponse(options: {
+export async function processImportResponse(options: {
+    api: D2Api;
     title: string;
     model: string;
     importResult: ImportReportResponse;
     splitStatsList: boolean;
-}): SynchronizationResult {
-    const { title, model, importResult, splitStatsList } = options;
+}): Promise<SynchronizationResult> {
+    const { api, title, model, importResult, splitStatsList } = options;
 
     const { bundleReport, status, validationReport } = importResult;
     const message = status === "OK" ? i18n.t("Import was successful") : i18n.t("Import failed");
@@ -69,12 +73,14 @@ export function processImportResponse(options: {
         details: "",
     }));
 
+    const detailedErrors = await getMetadataDetailsFromErrors(api, errors);
+
     if (!bundleReport) {
         return {
             title: title,
             status: status === "OK" ? "SUCCESS" : "ERROR",
             message: message,
-            errors: errors,
+            errors: detailedErrors,
             rawResponse: importResult,
         };
     }
@@ -138,6 +144,7 @@ export async function postImport(
         }
 
         return processImportResponse({
+            api,
             title,
             model: model,
             importResult: trackerJobReport,
@@ -147,6 +154,7 @@ export async function postImport(
         if (error?.response?.data) {
             if (error.response.data.validationReport) {
                 return processImportResponse({
+                    api,
                     title,
                     model: model,
                     importResult: error.response.data,
@@ -169,3 +177,49 @@ export async function postImport(
 async function getTrackerJobs(api: D2Api, trackerImportResponseId: Id): Promise<{ completed: boolean }[]> {
     return await api.get<{ completed: boolean }[]>(`/tracker/jobs/${trackerImportResponseId}`).getData();
 }
+
+export async function getMetadataDetailsFromErrors(api: D2Api, errors: ErrorMessage[]): Promise<ErrorMessage[]> {
+    const metadataIds = errors.flatMap(error => {
+        const uids = UidErrorMessage.extractUids(error.message);
+        return { id: error.id, uids };
+    });
+
+    const allIds = _.uniq(metadataIds.flatMap(item => item.uids));
+
+    const allItemsDetails = await promiseMap(_.chunk(allIds, 100), async (ids): Promise<Item[]> => {
+        const data = await api
+            .get<MetadataApiResponse>(
+                `/metadata?filter=id:in:[${ids.join(",")}]&fields=id,displayName,displayFormName,code`
+            )
+            .getData();
+        const items = getItemsFromMetadataResponse(data);
+        return items;
+    });
+
+    const allItems = _.flatten(allItemsDetails);
+
+    if (allItems.length === 0) return errors;
+
+    const allItemsById = new Map<string, string>(allItems.map(item => [item.id, item.name]));
+
+    const errorMessages = errors.map(error => {
+        return { ...error, message: UidErrorMessage.replaceUidsInMessage(error.message, allItemsById) };
+    });
+    return errorMessages;
+}
+
+type MetadataSimple = { id: string; displayFormName?: string; displayName?: string; code?: string };
+type MetadataApiResponse = { system: { id: string } } & Record<string, MetadataSimple[]>;
+
+type Item = { id: string; name: string };
+
+const getItemsFromMetadataResponse = (response: MetadataApiResponse): Item[] => {
+    const entries = Object.entries(response);
+
+    return entries.flatMap(([key, value]) => {
+        if (key === "system") return [];
+        if (!Array.isArray(value)) return [];
+
+        return value.map(obj => ({ id: obj.id, name: obj.displayFormName ?? obj.displayName ?? obj.code ?? "" }));
+    });
+};

--- a/src/data/Dhis2Import.ts
+++ b/src/data/Dhis2Import.ts
@@ -145,12 +145,21 @@ export async function postImport(
         });
     } catch (error: any) {
         if (error?.response?.data) {
-            return processImportResponse({
-                title,
-                model: model,
-                importResult: error.response.data,
-                splitStatsList,
-            });
+            if (error.response.data.validationReport) {
+                return processImportResponse({
+                    title,
+                    model: model,
+                    importResult: error.response.data,
+                    splitStatsList,
+                });
+            } else {
+                return {
+                    title: model,
+                    status: "ERROR",
+                    rawResponse: error.response,
+                    message: error.response.data.message,
+                };
+            }
         } else {
             return { title: model, status: "NETWORK ERROR", rawResponse: {} };
         }

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -55,6 +55,7 @@ import { promiseMap } from "../utils/promises";
 import { postEvents } from "./Dhis2Events";
 import { getProgram, getTrackedEntityInstances, updateTrackedEntityInstances } from "./Dhis2TrackedEntityInstances";
 import { Sharing } from "../domain/entities/Sharing";
+import { getMetadataDetailsFromErrors } from "./Dhis2Import";
 
 export class InstanceDhisRepository implements InstanceRepository {
     private api: D2Api;
@@ -477,13 +478,14 @@ export class InstanceDhisRepository implements InstanceRepository {
         const { status, description, conflicts, importCount } = importSummary;
         const { imported, deleted, updated, ignored } = importCount;
         const errors = conflicts?.map(({ object, value }) => ({ id: object, message: value, details: "" })) ?? [];
+        const errorDetails = await getMetadataDetailsFromErrors(this.api, errors);
 
         return {
             title,
             status,
             message: description,
             stats: [{ imported, deleted, updated, ignored }],
-            errors,
+            errors: errorDetails,
             rawResponse: importSummary,
         };
     }

--- a/src/data/UidErrorMessage.ts
+++ b/src/data/UidErrorMessage.ts
@@ -1,0 +1,31 @@
+import { Id } from "../domain/entities/ReferenceObject";
+
+const uidBase = "[A-Za-z][A-Za-z0-9]{10}";
+
+const uidWithBackTicksPattern = new RegExp(`\`(${uidBase})\``, "g");
+const uidPattern = new RegExp(`\\b${uidBase}\\b`, "g");
+
+export class UidErrorMessage {
+    static uidPattern = uidPattern;
+    static uidWithBackTicksPattern = uidWithBackTicksPattern;
+
+    static extractUids(text: string): Id[] {
+        const pattern = UidErrorMessage.uidPattern;
+        const matches = text.match(pattern);
+        return matches ? [...matches] : [];
+    }
+
+    static replaceUidsInMessage(message: string, metadataByIds: Map<Id, string>): string {
+        const withBackticksReplaced = message.replace(UidErrorMessage.uidWithBackTicksPattern, (_, captured) => {
+            const replacement = metadataByIds.get(captured);
+            return replacement ? `\`${replacement}\`` : `\`${captured}\``;
+        });
+
+        const errorMessage = withBackticksReplaced.replace(UidErrorMessage.uidPattern, captured => {
+            const replacement = metadataByIds.get(captured);
+            return replacement ?? captured;
+        });
+
+        return errorMessage;
+    }
+}

--- a/src/test/data/UidErrorMessage.spec.ts
+++ b/src/test/data/UidErrorMessage.spec.ts
@@ -1,0 +1,180 @@
+import { UidErrorMessage } from "../../data/UidErrorMessage";
+
+describe("UidErrorMessage", () => {
+    describe("extractUids", () => {
+        it("should extract a single valid UID from text", () => {
+            const text = "Error with object A1b2C3d4E5f";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual(["A1b2C3d4E5f"]);
+        });
+
+        it("should extract multiple valid UIDs from text", () => {
+            const text = "Error with A1b2C3d4E5f and B2c3D4e5F6g";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual(["A1b2C3d4E5f", "B2c3D4e5F6g"]);
+        });
+
+        it("should return empty array when no UIDs are present", () => {
+            const text = "No UIDs in this text";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual([]);
+        });
+
+        it("should return empty array for empty string", () => {
+            const text = "";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual([]);
+        });
+
+        it("should not extract invalid UIDs (not starting with letter)", () => {
+            const text = "Invalid UID: 11b2C3d4E5f";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual([]);
+        });
+
+        it("should not extract UIDs that are too short", () => {
+            const text = "Too short: A1b2C3d4E5";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual([]);
+        });
+
+        it("should not extract UIDs that are too long", () => {
+            const text = "Too long: A1b2C3d4E5f6g";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual([]);
+        });
+
+        it("should extract UIDs from complex error messages", () => {
+            const text = "Object `A1b2C3d4E5f` references `B2c3D4e5F6g` which does not exist";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual(["A1b2C3d4E5f", "B2c3D4e5F6g"]);
+        });
+
+        it("should extract multiple UIDs separated by special characters", () => {
+            const text = "UIDs: A1b2C3d4E5f, B2c3D4e5F6g";
+            const result = UidErrorMessage.extractUids(text);
+
+            expect(result).toEqual(["A1b2C3d4E5f", "B2c3D4e5F6g"]);
+        });
+    });
+
+    describe("replaceUidsInMessage", () => {
+        it("should replace a single UID with metadata name", () => {
+            const message = "Error with object `A1b2C3d4E5f`";
+            const metadataByIds = new Map([["A1b2C3d4E5f", "Organization Unit Name"]]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Error with object `Organization Unit Name`");
+        });
+
+        it("should replace multiple UIDs with metadata names", () => {
+            const message = "Object `A1b2C3d4E5f` references `B2c3D4e5F6g`";
+            const metadataByIds = new Map([
+                ["A1b2C3d4E5f", "Data Element 1"],
+                ["B2c3D4e5F6g", "Data Element 2"],
+            ]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Object `Data Element 1` references `Data Element 2`");
+        });
+
+        it("should keep original UID if metadata not found", () => {
+            const message = "Error with object `A1b2C3d4E5f`";
+            const metadataByIds = new Map<string, string>();
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Error with object `A1b2C3d4E5f`");
+        });
+        it("should replace some UIDs and keep others unchanged", () => {
+            const message = "Object `A1b2C3d4E5f` references `B2c3D4e5F6g`";
+            const metadataByIds = new Map([["A1b2C3d4E5f", "Known Element"]]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Object `Known Element` references `B2c3D4e5F6g`");
+        });
+
+        it("should not modify message without UIDs", () => {
+            const message = "Simple error message without UIDs";
+            const metadataByIds = new Map<string, string>();
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Simple error message without UIDs");
+        });
+
+        it("should preserve backticks when present and not add them when absent", () => {
+            const message = "Error with A1b2C3d4E5f and `B2c3D4e5F6g`";
+            const metadataByIds = new Map([
+                ["A1b2C3d4E5f", "Organization Unit 1"],
+                ["B2c3D4e5F6g", "Organization Unit 2"],
+            ]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Error with Organization Unit 1 and `Organization Unit 2`");
+        });
+
+        it("should handle empty message", () => {
+            const message = "";
+            const metadataByIds = new Map<string, string>();
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("");
+        });
+
+        it("should replace same UID multiple times in message", () => {
+            const message = "UID `A1b2C3d4E5f` appears twice: `A1b2C3d4E5f`";
+            const metadataByIds = new Map([["A1b2C3d4E5f", "Repeated Element"]]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("UID `Repeated Element` appears twice: `Repeated Element`");
+        });
+
+        it("should handle complex error messages with mixed replacements", () => {
+            const message =
+                "Cannot import `A1b2C3d4E5f` because it references `B2c3D4e5F6g` and `C3d4E5f6G7h` which are invalid";
+            const metadataByIds = new Map([
+                ["A1b2C3d4E5f", "Program Stage"],
+                ["C3d4E5f6G7h", "Data Element"],
+            ]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe(
+                "Cannot import `Program Stage` because it references `B2c3D4e5F6g` and `Data Element` which are invalid"
+            );
+        });
+
+        it("should preserve backticks in option set error message", () => {
+            const message = "Value `123123` is not a valid option code in option set `A1b2C3d4E5f`";
+            const metadataByIds = new Map([["A1b2C3d4E5f", "Other Medications"]]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Value `123123` is not a valid option code in option set `Other Medications`");
+        });
+
+        it("should replace UID without backticks when not present in original", () => {
+            const message = "Value `123123` is not a valid option code in option set A1b2C3d4E5f";
+            const metadataByIds = new Map([["A1b2C3d4E5f", "Other Medications"]]);
+
+            const result = UidErrorMessage.replaceUidsInMessage(message, metadataByIds);
+
+            expect(result).toBe("Value `123123` is not a valid option code in option set Other Medications");
+        });
+    });
+});


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/869akrrd3

### :memo: Implementation

- [x] Get error message if import endpoint returns a bad request response
- [x] Improve error messages by replacing the metadata id with `formName`, `name` or `code`

### :fire: Notes to the tester

These changes depends on this [PR](https://github.com/EyeSeeTea/Bulk-Load/pull/381) which solved some typescript errors in the development branch.

### :video_camera: Screenshots/Screen capture

**Error message from a file which throws a bad request response**

https://github.com/user-attachments/assets/bfda3813-6e52-4b85-8dcb-bf3bc13de028

**Error messages from a file which returns validation errors (program)**

https://github.com/user-attachments/assets/3905d889-5e6b-4ac0-be24-27d544befe1b

**Error messages from a file which returns validation errors (dataSet)**

https://github.com/user-attachments/assets/e5606aec-1de3-41b9-b16c-ba3d0a4b93ca

### :bookmark_tabs: Others

#869akrrd3