### PR TITLE
Feature: atomic uploads of TEI and Events

### DIFF
--- a/src/data/Dhis2Events.ts
+++ b/src/data/Dhis2Events.ts
@@ -5,19 +5,9 @@ import { SynchronizationResult } from "../domain/entities/SynchronizationResult"
 import i18n from "../utils/i18n";
 import { promiseMap } from "../utils/promises";
 import { ImportPostResponse, postImport } from "./Dhis2Import";
-import { Program, TrackedEntityInstance } from "../domain/entities/TrackedEntityInstance";
-import { getApiTeiToUpload, Metadata } from "./Dhis2TrackedEntityInstances";
-import { Maybe } from "../types/utils";
-import { ImportDataPackageOptions } from "../domain/repositories/InstanceRepository";
 
-export async function postEvents(
-    api: D2Api,
-    events: Event[],
-    options: Maybe<OptionEvents>
-): Promise<SynchronizationResult[]> {
-    const eventsWithEnrollment = options ? setEnrollmentToEvent(events, options) : events;
-
-    const eventsResult = await promiseMap(_.chunk(eventsWithEnrollment, 200), eventsToSave => {
+export async function postEvents(api: D2Api, events: Event[]): Promise<SynchronizationResult[]> {
+    return promiseMap(_.chunk(events, 200), eventsToSave => {
         return postImport(
             api,
             async () => await api.post<ImportPostResponse>("/tracker", {}, { events: eventsToSave }).getData(),
@@ -28,29 +18,4 @@ export async function postEvents(
             }
         );
     });
-
-    return eventsResult;
 }
-
-function setEnrollmentToEvent(events: Event[], options: OptionEvents): Event[] {
-    const { existingTeis, teis, program, metadata } = options;
-    const apiTeis = teis.map(tei => getApiTeiToUpload(program, metadata, tei, existingTeis, options.importOptions));
-    const teisByIds = _.keyBy(apiTeis, tei => tei.trackedEntity);
-    return events.map(event => {
-        const eventTeiId = event.trackedEntity ?? "";
-        const tei = teisByIds[eventTeiId];
-        const enrollmentId = tei?.enrollments[0]?.enrollment;
-        if (!enrollmentId) {
-            throw new Error(`Enrollment not found for event-tei: ${eventTeiId}-${event.trackedEntity}`);
-        }
-        return { ...event, enrollment: enrollmentId };
-    });
-}
-
-type OptionEvents = {
-    existingTeis: TrackedEntityInstance[];
-    teis: TrackedEntityInstance[];
-    program: Program;
-    metadata: Metadata;
-    importOptions: ImportDataPackageOptions;
-};

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -12,7 +12,7 @@ import { AttributeValue, Enrollment, Program, TrackedEntityInstance } from "../d
 import { parseDate } from "../domain/helpers/ExcelReader";
 import i18n from "../utils/i18n";
 import { D2Api, D2RelationshipType, Id, Ref } from "../types/d2-api";
-import { Dictionary, KeysOfUnion } from "../types/utils";
+import { KeysOfUnion } from "../types/utils";
 import { promiseMap } from "../utils/promises";
 import { getUid } from "./dhis2-uid";
 import {
@@ -167,14 +167,20 @@ export async function updateTrackedEntityInstances(
 
     return runSequentialPromisesOnSuccess([
         () =>
-            uploadTeis({ ...options, teis: preTeis, title: i18n.t("Create/update"), importOptions, events: eventsMap }),
+            uploadTeis({
+                ...options,
+                teis: preTeis,
+                title: i18n.t("Create/update"),
+                importOptions,
+                eventsByTei: eventsMap,
+            }),
         () =>
             uploadTeis({
                 ...options,
                 teis: postTeis,
                 title: i18n.t("Relationships"),
                 importOptions,
-                events: eventsMap,
+                eventsByTei: eventsMap,
             }),
     ]);
 }
@@ -242,13 +248,15 @@ async function uploadTeis(options: {
     existingTeis: TrackedEntityInstance[];
     title: string;
     importOptions: ImportDataPackageOptions;
-    events: Dictionary<Event[]>;
+    eventsByTei: EventMap;
 }): Promise<SynchronizationResult[]> {
-    const { api, importOptions, program, metadata, teis, existingTeis, title, events } = options;
+    const { api, importOptions, program, metadata, teis, existingTeis, title, eventsByTei } = options;
 
     if (_.isEmpty(teis)) return [];
 
-    const apiTeis = teis.map(tei => getApiTeiToUpload(program, metadata, tei, existingTeis, importOptions, events));
+    const apiTeis = teis.map(tei =>
+        getApiTeiToUpload({ program, metadata, tei, existingTeis, importOptions, eventsByTei })
+    );
     const model = i18n.t("Tracked Entity Instance");
 
     const teisResult = await promiseMap(_.chunk(apiTeis, 200), teisToSave => {
@@ -366,14 +374,15 @@ async function getApiEvents(
         .value();
 }
 
-export function getApiTeiToUpload(
-    program: Program,
-    metadata: Metadata,
-    tei: TrackedEntityInstance,
-    existingTeis: TrackedEntityInstance[],
-    importOptions: ImportDataPackageOptions,
-    events?: Dictionary<Event[]>
-): TrackedEntityToSave {
+function getApiTeiToUpload(options: {
+    program: Program;
+    metadata: Metadata;
+    tei: TrackedEntityInstance;
+    existingTeis: TrackedEntityInstance[];
+    importOptions: ImportDataPackageOptions;
+    eventsByTei: EventMap;
+}): TrackedEntityToSave {
+    const { program, metadata, tei, existingTeis, importOptions, eventsByTei } = options;
     const { orgUnit, enrollment, relationships } = tei;
     const optionById = _.keyBy(metadata.options, option => option.id);
 
@@ -398,7 +407,7 @@ export function getApiTeiToUpload(
         };
     });
 
-    const enrollmentEvents = events?.[tei.id] || [];
+    const enrollmentEvents = eventsByTei?.[tei.id] || [];
     const apiEvents = enrollmentEvents.map(event => ({ ...event, enrollment: enrollmentId }));
 
     return {
@@ -662,6 +671,9 @@ export type TrackedEntitiesD2ApiResponse = {
     };
     pageCount?: number;
 };
+
+type TEIId = string;
+type EventMap = Record<TEIId, Event[]>;
 
 type EnrollmentWithEvents = Enrollment & { events: Event[] };
 type TrackedEntityToSave = Omit<TrackedEntity, "enrollments"> & {

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -12,10 +12,9 @@ import { AttributeValue, Enrollment, Program, TrackedEntityInstance } from "../d
 import { parseDate } from "../domain/helpers/ExcelReader";
 import i18n from "../utils/i18n";
 import { D2Api, D2RelationshipType, Id, Ref } from "../types/d2-api";
-import { KeysOfUnion } from "../types/utils";
+import { Dictionary, KeysOfUnion } from "../types/utils";
 import { promiseMap } from "../utils/promises";
 import { getUid } from "./dhis2-uid";
-import { postEvents } from "./Dhis2Events";
 import {
     buildOrgUnitMode,
     fromApiRelationships,
@@ -162,13 +161,21 @@ export async function updateTrackedEntityInstances(
     if (!program) throw new Error(`Program not found: ${programId}`);
 
     const apiEvents = await getApiEvents(api, teis, dataEntries, metadata, teiSeed);
+    const eventsMap = _.groupBy(apiEvents, event => event.trackedEntity);
     const { preTeis, postTeis } = await splitTeis(api, teis, metadata);
     const options = { api, program, metadata, existingTeis };
 
     return runSequentialPromisesOnSuccess([
-        () => uploadTeis({ ...options, teis: preTeis, title: i18n.t("Create/update"), importOptions }),
-        () => uploadTeis({ ...options, teis: postTeis, title: i18n.t("Relationships"), importOptions }),
-        () => postEvents(api, apiEvents, { existingTeis, teis: teis, program, metadata, importOptions }),
+        () =>
+            uploadTeis({ ...options, teis: preTeis, title: i18n.t("Create/update"), importOptions, events: eventsMap }),
+        () =>
+            uploadTeis({
+                ...options,
+                teis: postTeis,
+                title: i18n.t("Relationships"),
+                importOptions,
+                events: eventsMap,
+            }),
     ]);
 }
 
@@ -235,12 +242,13 @@ async function uploadTeis(options: {
     existingTeis: TrackedEntityInstance[];
     title: string;
     importOptions: ImportDataPackageOptions;
+    events: Dictionary<Event[]>;
 }): Promise<SynchronizationResult[]> {
-    const { api, importOptions, program, metadata, teis, existingTeis, title } = options;
+    const { api, importOptions, program, metadata, teis, existingTeis, title, events } = options;
 
     if (_.isEmpty(teis)) return [];
 
-    const apiTeis = teis.map(tei => getApiTeiToUpload(program, metadata, tei, existingTeis, importOptions));
+    const apiTeis = teis.map(tei => getApiTeiToUpload(program, metadata, tei, existingTeis, importOptions, events));
     const model = i18n.t("Tracked Entity Instance");
 
     const teisResult = await promiseMap(_.chunk(apiTeis, 200), teisToSave => {
@@ -363,8 +371,9 @@ export function getApiTeiToUpload(
     metadata: Metadata,
     tei: TrackedEntityInstance,
     existingTeis: TrackedEntityInstance[],
-    importOptions: ImportDataPackageOptions
-): TrackedEntity {
+    importOptions: ImportDataPackageOptions,
+    events?: Dictionary<Event[]>
+): TrackedEntityToSave {
     const { orgUnit, enrollment, relationships } = tei;
     const optionById = _.keyBy(metadata.options, option => option.id);
 
@@ -389,6 +398,9 @@ export function getApiTeiToUpload(
         };
     });
 
+    const enrollmentEvents = events?.[tei.id] || [];
+    const apiEvents = enrollmentEvents.map(event => ({ ...event, enrollment: enrollmentId }));
+
     return {
         trackedEntity: tei.id,
         trackedEntityType: program.trackedEntityType.id,
@@ -404,6 +416,7 @@ export function getApiTeiToUpload(
                           enrolledAt: enrollment.enrolledAt,
                           occurredAt: enrollment.occurredAt || enrollment.enrolledAt,
                           attributes: attributes,
+                          events: apiEvents,
                       },
                   ]
                 : [],
@@ -648,6 +661,11 @@ export type TrackedEntitiesD2ApiResponse = {
         pageCount: number;
     };
     pageCount?: number;
+};
+
+type EnrollmentWithEvents = Enrollment & { events: Event[] };
+type TrackedEntityToSave = Omit<TrackedEntity, "enrollments"> & {
+    enrollments: EnrollmentWithEvents[];
 };
 
 const constraintfields = {

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -407,7 +407,7 @@ function getApiTeiToUpload(options: {
         };
     });
 
-    const enrollmentEvents = eventsByTei?.[tei.id] || [];
+    const enrollmentEvents = eventsByTei[tei.id] || [];
     const apiEvents = enrollmentEvents.map(event => ({ ...event, enrollment: enrollmentId }));
 
     return {

--- a/src/data/InstanceDhisRepository.ts
+++ b/src/data/InstanceDhisRepository.ts
@@ -541,8 +541,7 @@ export class InstanceDhisRepository implements InstanceRepository {
             };
         });
 
-        // third value only required for program trackers
-        return postEvents(this.api, eventsToSave, undefined);
+        return postEvents(this.api, eventsToSave);
     }
 
     private async getEventProgramStage(programId: Id): Promise<Ref | undefined> {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes # [Estimate: Atomic uploads for tracker programs](https://app.clickup.com/t/869bac1rw)
* **d2-api**: Requires #
* **d2-ui-components**: Requires #

### :memo: Implementation
- update TEI payload to include events inside enrollments

### :fire: Notes for the reviewer

### :art: Screenshots
Screenshots instead of screen record because importing takes too long
**Import results - 3 TEIs and 3 events included instead of 2 separate reports**
<img width="855" height="593" alt="image" src="https://github.com/user-attachments/assets/cc23b2e6-9e29-4a69-8f2b-b266dd8d77b7" />

**Import results - valid 3 valid TEI with invalid values in the events**
<img width="863" height="688" alt="image" src="https://github.com/user-attachments/assets/18b37b7b-acea-4f94-8b48-2148539c442f" />

### :bookmark_tabs: Others
