### PR TITLE
suppress warning message on the test/build execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
         "@eyeseetea/d2-api": "1.20.0",
-        "@eyeseetea/d2-ui-components": "2.11.0-beta.1",
+        "@eyeseetea/d2-ui-components": "2.12.0",
         "@eyeseetea/feedback-component": "0.1.3-beta.3",
         "@eyeseetea/xlsx-populate": "4.3.2-beta.1",
         "@material-ui/core": "4.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,10 +4642,10 @@
     qs "6.9.7"
     react "^16.12.0"
 
-"@eyeseetea/d2-ui-components@2.11.0-beta.1":
-  version "2.11.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-ui-components/-/d2-ui-components-2.11.0-beta.1.tgz#b4b4c76285a03f4f99d2645d8c7476122da8f289"
-  integrity sha512-OLBphENbEUQjVe94rqKqaw9vClPLXeYSIAD0Zpx7etnY2Out2lh5DOl97muff13mKJmvN6u35BApp7DLnX0X0g==
+"@eyeseetea/d2-ui-components@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-ui-components/-/d2-ui-components-2.12.0.tgz#dabef61e90f42796deefe891393646fc917abb2e"
+  integrity sha512-lH+kuDsxU/N4MlDrBJcTBECyQF0YQkWrShu+zICzlSm4AAqq6FEqq20xrloJr1fHoB35/OmYVyry35kMwWfwdA==
   dependencies:
     "@date-io/core" "1.3.6"
     "@date-io/moment" "1.0.2"
@@ -4659,7 +4659,6 @@
     moment "2.29.4"
     nano-memoize "1.2.1"
     react-linkify "1.0.0-alpha"
-    rxjs-compat "6.6.3"
     throttle-debounce "2.1.0"
 
 "@eyeseetea/feedback-component@0.1.3-beta.3":
@@ -17607,11 +17606,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
-
-rxjs-compat@6.6.3:
-  version "6.6.3"
-  resolved "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.3.tgz#141405fcee11f48718d428b99c8f01826f594e5c"
-  integrity sha512-y+wUqq7bS2dG+7rH2fNMoxsDiJ32RQzFxZQE/JdtpnmEZmwLQrb1tCiItyHxdXJHXjmHnnzFscn3b6PEmORGKw==
 
 rxjs-compat@6.6.7:
   version "6.6.7"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/869apq1p0

### :memo: Implementation

- This warning message:

```shell
console.warn
      Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
```

was related to an unused dependency on d2-ui-components. This was fixed on [this PR](https://github.com/EyeSeeTea/d2-ui-components/pull/249). Updating to the latest version fixed the problem.

- About the `ERR_UNHANDLED_REJECTION` I was getting this error but I couldn't trace this back to a specific dependency or code. After removing the `node_modules` folder and re-installing `yarn install` the error did not show up again. It could be related to an old dependency, but not really sure.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/3873e86c-0d8c-4e85-9275-8cd155b5b261

### :bookmark_tabs: Others

#869apq1p0