### PR TITLE
fix(tracker): use v42 tracker API params for org unit filtering

### DIFF
--- a/src/data/Dhis2RelationshipTypes.ts
+++ b/src/data/Dhis2RelationshipTypes.ts
@@ -20,12 +20,11 @@ export type RelationshipOrgUnitFilter = TrackedEntityOURequestApi["ouMode"];
 
 export function buildOrgUnitMode(ouMode: RelationshipOrgUnitFilter, orgUnits?: Ref[]) {
     const isOuReq = ouMode === "SELECTED" || ouMode === "CHILDREN" || ouMode === "DESCENDANTS";
-    //issue: v41 - orgUnitMode/ouMode; v38-40 ouMode; ouMode to be deprecated
-    //can't use both orgUnitMode and ouMode in v41
+    // /tracker/trackedEntities uses orgUnitMode (ouMode deprecated since v41, ignored in v42+)
     if (!isOuReq) {
-        return { ouMode };
+        return { orgUnitMode: ouMode };
     } else if (orgUnits && orgUnits.length > 0) {
-        return { ouMode, orgUnit: buildOrgUnitsParameter(orgUnits) };
+        return { orgUnitMode: ouMode, orgUnits: buildOrgUnitsParameter(orgUnits) };
     } else {
         throw new Error(`No orgUnits selected for ouMode ${ouMode}`);
     }

--- a/src/data/Dhis2TrackedEntityInstances.ts
+++ b/src/data/Dhis2TrackedEntityInstances.ts
@@ -42,7 +42,7 @@ export interface GetOptions {
 type TrackerParams = Params & Omit<TeiGetRequest, "ou" | "ouMode">;
 
 export interface TrackedEntityGetRequest extends TrackerParams {
-    orgUnit?: string;
+    orgUnits?: string;
     orgUnitMode?: TeiGetRequest["ouMode"];
     trackedEntity?: string;
     enrollmentEnrolledAfter?: string;
@@ -463,7 +463,7 @@ function getMultiTextValue(options: {
 
 async function getExistingTeis(api: D2Api): Promise<Ref[]> {
     const query = {
-        ouMode: "CAPTURE",
+        orgUnitMode: "CAPTURE",
         pageSize: 1000,
         totalPages: true,
         fields: "trackedEntity",

--- a/src/domain/entities/OrgUnit.ts
+++ b/src/domain/entities/OrgUnit.ts
@@ -8,5 +8,5 @@ export interface OrgUnit {
 }
 
 export function buildOrgUnitsParameter(orgUnitsIds: Ref[]): string {
-    return orgUnitsIds.map(({ id }) => id).join(";");
+    return orgUnitsIds.map(({ id }) => id).join(",");
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `ouMode` with `orgUnitMode`, `orgUnit` with `orgUnits` (plural), and semicolon delimiter with commas for `/tracker/trackedEntities` endpoint
- Fixes TEI population ignoring selected org units in DHIS2 v42 (returns all accessible TEIs instead of only selected OUs, causing slow performance and incorrect data)

## Related Tasks
- [Bulk Load - data population for tracker ignores selected OU in dhis2 v42](https://app.clickup.com/t/869cb326m)

## Test plan
- [x] Unit tests pass (54/54)
- [x] TypeScript compiles cleanly
- [x] Manual verification: download populated tracker template on DHIS2 v42 with "Only selected organisation units" — TEIs filtered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)