### PR TITLE
populate fixedOrgUnit and fixedPeriod when downloading empty template

### DIFF
--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -196,24 +196,24 @@ export class DownloadTemplateUseCase implements UseCase {
 
         if (theme) await builder.applyTheme(template, theme);
 
+        if (template.type === "custom" && template.fixedOrgUnit) {
+            await this.excelRepository.writeCell(
+                template.id,
+                template.fixedOrgUnit,
+                dataPackage?.dataEntries[0]?.orgUnit ?? this.getFirstValueOrEmpty(orgUnits)
+            );
+        }
+
+        if (template.type === "custom" && template.fixedPeriod) {
+            const periods = buildAllPossiblePeriods(element.periodType, populateStartDate, populateEndDate);
+            await this.excelRepository.writeCell(
+                template.id,
+                template.fixedPeriod,
+                dataPackage?.dataEntries[0]?.period ?? this.getFirstValueOrEmpty(periods)
+            );
+        }
+
         if (enablePopulate) {
-            if (template.type === "custom" && template.fixedOrgUnit) {
-                await this.excelRepository.writeCell(
-                    template.id,
-                    template.fixedOrgUnit,
-                    dataPackage?.dataEntries[0]?.orgUnit ?? this.getFirstValueOrEmpty(orgUnits)
-                );
-            }
-
-            if (template.type === "custom" && template.fixedPeriod) {
-                const periods = buildAllPossiblePeriods(element.periodType, populateStartDate, populateEndDate);
-                await this.excelRepository.writeCell(
-                    template.id,
-                    template.fixedPeriod,
-                    dataPackage?.dataEntries[0]?.period ?? this.getFirstValueOrEmpty(periods)
-                );
-            }
-
             if (dataPackage) {
                 await builder.populateTemplate(template, dataPackage, settings);
             }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #869cnjxd4
* **d2-api**: Requires #
* **d2-ui-components**: Requires #

### :memo: Implementation
- populate `fixedOrgUnit` and `fixedPeriod` regardless of populate selection

### :fire: Notes for the reviewer

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/56c72f55-39bc-463f-b7bf-b24740ff0b69


### :bookmark_tabs: Others
