### PR TITLE
[fix]: Replace invalid XML characters from cell values during export

### DIFF
--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -5,7 +5,7 @@ import XLSX, {
     Workbook as ExcelWorkbook,
     Workbook,
 } from "@eyeseetea/xlsx-populate";
-import _, { isString } from "lodash";
+import _ from "lodash";
 import moment from "moment";
 import { CellDataValidation } from "../domain/entities/CellDataValidation";
 import { Sheet } from "../domain/entities/Sheet";
@@ -24,7 +24,7 @@ import { ExcelRepository, ExcelValue, LoadOptions, ReadCellOptions } from "../do
 import i18n from "../utils/i18n";
 import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
-import { removeCharacters, replaceInvalidXmlChars } from "../utils/string";
+import { isString, removeCharacters, replaceInvalidXmlChars } from "../utils/string";
 import { Maybe } from "../types/utils";
 
 export class ExcelPopulateRepository extends ExcelRepository {

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -24,7 +24,7 @@ import { ExcelRepository, ExcelValue, LoadOptions, ReadCellOptions } from "../do
 import i18n from "../utils/i18n";
 import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
-import { removeCharacters } from "../utils/string";
+import { removeCharacters, replaceInvalidXmlChars } from "../utils/string";
 import { Maybe } from "../types/utils";
 
 export class ExcelPopulateRepository extends ExcelRepository {
@@ -116,14 +116,15 @@ export class ExcelPopulateRepository extends ExcelRepository {
 
         const { startCell: destination = cell } = mergedCells.find(range => range.hasCell(cell)) ?? {};
 
-        if (!!value && !isNaN(Number(value))) {
-            destination.value(Number(value));
-        } else if (String(value).startsWith("=")) {
-            destination.formula(String(value));
+        const safeValue = typeof value === "string" ? replaceInvalidXmlChars(value) : value;
+        if (!!safeValue && !isNaN(Number(safeValue))) {
+            destination.value(Number(safeValue));
+        } else if (String(safeValue).startsWith("=")) {
+            destination.formula(String(safeValue));
         } else if (definedName) {
             destination.formula(`=${definedName}`);
         } else {
-            destination.value(value);
+            destination.value(safeValue);
         }
     }
 

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -5,7 +5,7 @@ import XLSX, {
     Workbook as ExcelWorkbook,
     Workbook,
 } from "@eyeseetea/xlsx-populate";
-import _ from "lodash";
+import _, { isString } from "lodash";
 import moment from "moment";
 import { CellDataValidation } from "../domain/entities/CellDataValidation";
 import { Sheet } from "../domain/entities/Sheet";
@@ -116,8 +116,8 @@ export class ExcelPopulateRepository extends ExcelRepository {
 
         const { startCell: destination = cell } = mergedCells.find(range => range.hasCell(cell)) ?? {};
 
-        const safeValue = typeof value === "string" ? replaceInvalidXmlChars(value) : value;
-        if (!!safeValue && !isNaN(Number(safeValue))) {
+        const safeValue = isString(value) ? replaceInvalidXmlChars(value) : value;
+        if (safeValue && !isNaN(Number(safeValue))) {
             destination.value(Number(safeValue));
         } else if (String(safeValue).startsWith("=")) {
             destination.formula(String(safeValue));

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -5,3 +5,14 @@ export function removeCharacters(value: unknown): string {
 export function isString(value: unknown): value is string {
     return typeof value === "string";
 }
+
+// XML 1.0 forbids most C0 control characters. The xlsx format is XML, so any
+// such character in a string cell breaks the file in MS Excel (LibreOffice
+// silently strips them). Preserve \t (\x09), \n (\x0A) and \r (\x0D) — the
+// only whitespace controls XML allows.
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+export function replaceInvalidXmlChars(text: string): string {
+    return text.replace(INVALID_XML_CHARS_RE, " ");
+}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/869dbc90g

### :memo: Implementation
Excel-generated `.xlsx` files fail to open in MS Excel when a DHIS2 string value contains a C0 control character (e.g. vertical tab `\x0B`), because the xlsx format is XML 1.0 which forbids those bytes.
- Adds `stripInvalidXmlChars` in `src/utils/string.ts` that replaces invalid XML 1.0 control chars (`\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F`, `\x7F`) with a space, preserving the XML-safe whitespace controls (`\t`, `\n`, `\r`).
- Applies the sanitizer at the export point — `ExcelPopulateRepository.writeCell` — so every string value reaching `xlsx-populate` is safe. Numeric, boolean, formula and defined-name branches are untouched.



#869dbc90g