### PR TITLE
fix: don't cache getSheetRowsCount / getSheetFinalColumn across file uploads

### DIFF
--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -22,7 +22,6 @@ import {
 import { ThemeStyle } from "../domain/entities/Theme";
 import { ExcelRepository, ExcelValue, LoadOptions, ReadCellOptions } from "../domain/repositories/ExcelRepository";
 import i18n from "../utils/i18n";
-import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
 import { removeCharacters } from "../utils/string";
 import { Maybe } from "../types/utils";
@@ -338,7 +337,6 @@ export class ExcelPopulateRepository extends ExcelRepository {
         }
     }
 
-    @cache()
     public async getSheetRowsCount(id: string, sheetId: string | number): Promise<number | undefined> {
         const workbook = await this.getWorkbook(id);
         const sheet = workbook.sheet(sheetId);
@@ -356,7 +354,6 @@ export class ExcelPopulateRepository extends ExcelRepository {
         return lastRowWithValues ? lastRowWithValues.rowNumber() : 0;
     }
 
-    @cache()
     public async getSheetFinalColumn(id: string, sheetId: string | number): Promise<string | undefined> {
         const workbook = await this.getWorkbook(id);
         const sheet = workbook.sheet(sheetId);


### PR DESCRIPTION
## ClickUp

Closes: https://app.clickup.com/t/869devcx5 #869devcx5

## Problem

When multiple spreadsheets are imported in the same session, the row count (and final column) of every file after the first could be silently wrong.

Root cause: `getSheetRowsCount` and `getSheetFinalColumn` were decorated with `@cache()`. The cache key is derived from the method arguments `(id, sheetId)`. However, all spreadsheets generated from the same Bulk Load template share **the same template version ID** — it is read from the spreadsheet itself (`Version_ID` defined name or cell A1), not generated per upload. As a result:

1. File 1 is loaded → `this.workbooks[id]` is set → `getSheetRowsCount(id, sheet)` computes and **caches** the row count (e.g. 100).
2. File 2 is loaded → `this.workbooks[id]` is **overwritten** with the new workbook.
3. `getSheetRowsCount(id, sheet)` is called again → the decorator returns the **stale cached value** (100) instead of reading from the new workbook.
4. Rows beyond position 100 in any subsequent file are never read → **silent data loss** with no error shown in the UI.

Files smaller than the first are unaffected (their row count falls within the cached limit). Files larger than the first are truncated at the first file's row count.

This affects **all three import strategies** (DELETE AND IMPORT, IMPORT NEW VALUES ONLY, UPDATE AND IMPORT) because the row-reading step happens before the strategy is applied.

## Fix

Remove `@cache()` from `getSheetRowsCount` and `getSheetFinalColumn`. Both methods scan an already in-memory JS array — no I/O involved — so the performance cost of not caching is negligible.

## Test plan

- [ ] Import three or more spreadsheets of the same template type in a single session where a later file has more rows than the first; verify all rows are imported
- [ ] Confirm behaviour for all three import strategies (DELETE AND IMPORT, IMPORT NEW VALUES ONLY, UPDATE AND IMPORT)
- [ ] All existing unit tests pass (54/54 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)