### PR TITLE
Release 3.33.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bulk-load",
     "description": "Bulk importing made easy",
-    "version": "3.32.0",
+    "version": "3.33.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -22,7 +22,6 @@ import {
 import { ThemeStyle } from "../domain/entities/Theme";
 import { ExcelRepository, ExcelValue, LoadOptions, ReadCellOptions } from "../domain/repositories/ExcelRepository";
 import i18n from "../utils/i18n";
-import { cache } from "../utils/cache";
 import { fromBase64 } from "../utils/files";
 import { removeCharacters } from "../utils/string";
 import { Maybe } from "../types/utils";
@@ -338,7 +337,6 @@ export class ExcelPopulateRepository extends ExcelRepository {
         }
     }
 
-    @cache()
     public async getSheetRowsCount(id: string, sheetId: string | number): Promise<number | undefined> {
         const workbook = await this.getWorkbook(id);
         const sheet = workbook.sheet(sheetId);
@@ -356,7 +354,6 @@ export class ExcelPopulateRepository extends ExcelRepository {
         return lastRowWithValues ? lastRowWithValues.rowNumber() : 0;
     }
 
-    @cache()
     public async getSheetFinalColumn(id: string, sheetId: string | number): Promise<string | undefined> {
         const workbook = await this.getWorkbook(id);
         const sheet = workbook.sheet(sheetId);


### PR DESCRIPTION
## Changes

### Bug fixes

- **fix: don't cache getSheetRowsCount / getSheetFinalColumn across file uploads** — PR #401

  When multiple spreadsheets from the same template were imported in a single session, the `@cache()` decorator on `getSheetRowsCount` and `getSheetFinalColumn` returned stale values from the first file for all subsequent files. Any file with more rows than the first was silently truncated at the first file's row count with no error shown in the UI. Affects all three import strategies (DELETE AND IMPORT, IMPORT NEW VALUES ONLY, UPDATE AND IMPORT). Fixed by removing the decorator — both methods scan an in-memory JS array so caching provides no meaningful benefit.

## Commits

- `ea61804` fix: don't cache getSheetRowsCount / getSheetFinalColumn across file uploads
- `6ba4703` Merge pull request #401 from EyeSeeTea/fix/stale-row-count-cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)