### PR TITLE
ignore empty formula rows on bulk load for faster uploads

### DIFF
--- a/src/data/ExcelPopulateRepository.ts
+++ b/src/data/ExcelPopulateRepository.ts
@@ -26,6 +26,9 @@ import { fromBase64 } from "../utils/files";
 import { isString, removeCharacters, replaceInvalidXmlChars } from "../utils/string";
 import { Maybe } from "../types/utils";
 
+// Common result of a spreadsheet lookup formula that does not find a value. Invalid in DHIS2.
+const NOT_AVAILABLE_VALUE = "#N/A";
+
 export class ExcelPopulateRepository extends ExcelRepository {
     private workbooks: Record<string, ExcelWorkbook> = {};
 
@@ -231,7 +234,7 @@ export class ExcelPopulateRepository extends ExcelRepository {
     // formulas that result to blank cells store the raw formula in the value
     // use #N/A as default value instead of blank
     private resolveNA(value: Maybe<ExcelValue>, formula: Maybe<ExcelValue>): Maybe<ExcelValue> {
-        if (value === "#N/A") return "";
+        if (value === NOT_AVAILABLE_VALUE) return "";
         return value ?? formula;
     }
 
@@ -348,7 +351,7 @@ export class ExcelPopulateRepository extends ExcelRepository {
             .dropRightWhile(row =>
                 _((row as RowWithCells)._cells)
                     .compact()
-                    .every(c => c.value() === undefined)
+                    .every(c => isBlankCellValue(c.value()))
             )
             .last();
 
@@ -602,6 +605,12 @@ function getDefinedName(workbook: XLSX.Workbook, cell: XLSX.Cell): string | unde
     } else if (isCell(element)) {
         return String(element.value());
     }
+}
+
+// Empty formula cells resolve to undefined, "" or #N/A (see resolveNA / #N/A workaround).
+// Reason: treat all three as blank so trailing empty rows don't inflate the read range.
+function isBlankCellValue(value: unknown): boolean {
+    return value === undefined || value === "" || value === NOT_AVAILABLE_VALUE;
 }
 
 function getValue(cell: Cell): ExcelValue | undefined {


### PR DESCRIPTION
### :pushpin: References

- **Issue:** Closes #869dg8vnz
- **d2-api**: Requires #
- **d2-ui-components**: Requires #

### :memo: Implementation

- `getSheetRowsCount` only trimmed trailing rows whose cells were `undefined`. Lookup formulas (added with function support) resolve empty rows to `"#N/A"`/`""`, which are not `undefined`, so those rows stopped being trimmed and the read range spanned every formula row (~500).
- Treat `undefined`, `""` and `"#N/A"` as blank when finding the last data row, mirroring `resolveNA` at the row-count layer instead of per-cell.

Previously reported upload times:
upload time avg: 1m 4s
import time avg: 1m 45s

After updates:
upload time avg: 6s
import time avg: unchanged

### :fire: Notes for the reviewer

- No change to imported data: the trimmed rows resolve entirely to blank and produce no data values (verified — the PHSM tracker template parses identical entries/values before and after: full file `3 entries / 687 values`, single-row file `1 / 229`). Only the wasted scanning of dead rows is removed.
- Performance: PHSM tracker template parse drops from **~80s to ~2.3s** (it was reading ~100k+ cells across ~490 empty formula rows, 3 reads each).
- Only **trailing** blank rows are trimmed (`dropRightWhile`), so a late data start (e.g. entry beginning at row 18) and middle gaps are unaffected.
- Templates that read single cells (the NHWA/CNPS/MAL family) are unaffected — they don't use auto-`rowEnd` range reads.

### :video_camera: Screenshots/Screen capture

Templates used for testing:
[PHSM - Policy Tracker - one line.xlsm](https://github.com/user-attachments/files/28742662/PHSM.-.Policy.Tracker.-.one.line.xlsm)
[PHSM - Policy Tracker.xlsm](https://github.com/user-attachments/files/28742657/PHSM.-.Policy.Tracker.xlsm)


### :bookmark_tabs: Others
