### PR TITLE
[Feature] multi org unit selection and alphabetical row order for custom dataSets

### DIFF
--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -94,6 +94,9 @@ export interface CustomTemplateWithUrl extends BaseTemplate {
     // Hidden author-set opt-in for multi org unit selection on custom dataSets.
     // Do not combine with fixedOrgUnit, which only writes the first org unit.
     allowMultipleOrgUnits?: boolean;
+    // Hidden author-set opt-in for the exported org unit row order. "ALPHABETICAL" = hierarchy pre-order
+    // with siblings by name. Only meaningful with multiple org units, so pair with allowMultipleOrgUnits.
+    orgUnitSort?: "ALPHABETICAL";
     showLanguage?: boolean;
     showPeriod?: boolean;
     downloadCustomization?: (

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -91,6 +91,9 @@ export interface CustomTemplateWithUrl extends BaseTemplate {
     description: string;
     fixedOrgUnit?: CellRef;
     fixedPeriod?: CellRef;
+    // Hidden author-set opt-in for multi org unit selection on custom dataSets.
+    // Do not combine with fixedOrgUnit, which only writes the first org unit.
+    allowMultipleOrgUnits?: boolean;
     showLanguage?: boolean;
     showPeriod?: boolean;
     downloadCustomization?: (

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -168,6 +168,13 @@ export class DownloadTemplateUseCase implements UseCase {
             }
         }
 
+        if (dataPackage?.type === "dataSets" && template.type === "custom" && template.orgUnitSort === "ALPHABETICAL") {
+            dataPackage = {
+                ...dataPackage,
+                dataEntries: sortDataEntriesByOrgUnitName(dataPackage.dataEntries, element.organisationUnits),
+            };
+        }
+
         const maxTeiRows =
             dataPackage?.type === "trackerPrograms" && enablePopulate
                 ? dataPackage.trackedEntityInstances.length
@@ -263,12 +270,36 @@ export class DownloadTemplateUseCase implements UseCase {
     }
 }
 
+type OrgUnitNameRef = { id: Id; path: string; displayName: string };
+
+// Joins an org unit's ancestor names into one sortable key. The NUL char is the separator because it is
+// the only one guaranteed to sort before every real character and to never appear in a name, so a
+// parent's key is always a prefix of its children's. Sorting these keys reproduces the org unit tree:
+// pre-order (parent before children), siblings ordered by name.
+const ANCESTOR_NAME_SEPARATOR = "\u0000";
+
+function sortDataEntriesByOrgUnitName<T extends { orgUnit: Id }>(
+    dataEntries: T[],
+    organisationUnits: OrgUnitNameRef[]
+): T[] {
+    const ouById = _.keyBy(organisationUnits, ou => ou.id);
+
+    const ancestorNameKey = (orgUnitId: Id): string =>
+        _(ouById[orgUnitId]?.path ?? orgUnitId)
+            .split("/")
+            .compact()
+            .map(segmentId => ouById[segmentId]?.displayName ?? segmentId)
+            .join(ANCESTOR_NAME_SEPARATOR);
+
+    return _.sortBy(dataEntries, entry => ancestorNameKey(entry.orgUnit));
+}
+
 async function getElement(api: D2Api, type: DataFormType, id: string) {
     const endpoint = type === dataFormTypeMap.dataSets ? "dataSets" : "programs";
     const fields = [
         "id",
         "displayName",
-        "organisationUnits[id,path]",
+        "organisationUnits[id,path,displayName]",
         "attributeValues[attribute[code],value]",
         "categoryCombo",
         "dataSetElements",

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -75,6 +75,7 @@ export const TemplateSelector = ({
     const [datePickerFormat, setDatePickerFormat] = useState<PickerFormat>();
     const [userHasReadAccess, setUserHasReadAccess] = useState<boolean>(false);
     const [filterOrgUnits, setFilterOrgUnits] = useState<boolean>(true);
+    const [allowMultipleOrgUnits, setAllowMultipleOrgUnits] = useState<boolean>(false);
     const [selectedModel, setSelectedModel] = useState<string>("");
     const [state, setState] = useState<PartialBy<TemplateSelectorState, "type" | "id" | "templateId" | "templateType">>(
         {
@@ -217,6 +218,7 @@ export const TemplateSelector = ({
                 }));
                 clearPopulateDates();
                 setSelectedOrgUnits([]);
+                setAllowMultipleOrgUnits(false);
                 return;
             }
 
@@ -236,6 +238,8 @@ export const TemplateSelector = ({
 
             const customTemplate = customTemplates.find(t => t.id === templateId);
             const templateType: TemplateType = customTemplate ? "custom" : "generated";
+
+            setAllowMultipleOrgUnits(customTemplate?.allowMultipleOrgUnits ?? false);
 
             const teiFilter =
                 templateType === "custom" && type === "trackerPrograms" && customTemplate?.filters?.teiFilters;
@@ -349,7 +353,7 @@ export const TemplateSelector = ({
             : i18n.t("Select available organisation units to include in the template");
 
     const isCustomDataSet = state.templateType === "custom" && state.type === "dataSets";
-    const isMultipleSelection = !isCustomDataSet;
+    const isMultipleSelection = !isCustomDataSet || allowMultipleOrgUnits;
     const showPopulate = !(state.templateType === "custom" && !settings.showPopulateInCustomForms);
     const selected = state.id && state.templateId ? getOptionValue({ id: state.id, templateId: state.templateId }) : "";
     const hasDataFilter = Boolean(state.dataFilterOptions.teiFilter?.filters.length);

--- a/src/webapp/components/template-selector/TemplateSelector.tsx
+++ b/src/webapp/components/template-selector/TemplateSelector.tsx
@@ -75,7 +75,6 @@ export const TemplateSelector = ({
     const [datePickerFormat, setDatePickerFormat] = useState<PickerFormat>();
     const [userHasReadAccess, setUserHasReadAccess] = useState<boolean>(false);
     const [filterOrgUnits, setFilterOrgUnits] = useState<boolean>(true);
-    const [allowMultipleOrgUnits, setAllowMultipleOrgUnits] = useState<boolean>(false);
     const [selectedModel, setSelectedModel] = useState<string>("");
     const [state, setState] = useState<PartialBy<TemplateSelectorState, "type" | "id" | "templateId" | "templateType">>(
         {
@@ -99,6 +98,10 @@ export const TemplateSelector = ({
 
     const dataSets = dataSource?.dataSets;
     const { templateId, id } = state;
+
+    const activeCustomTemplate =
+        state.templateType === "custom" ? customTemplates.find(t => t.id === templateId) : undefined;
+    const allowMultipleOrgUnits = Boolean(activeCustomTemplate?.allowMultipleOrgUnits);
 
     const isDataSet = React.useMemo(() => {
         if (!dataSets) return false;
@@ -218,7 +221,6 @@ export const TemplateSelector = ({
                 }));
                 clearPopulateDates();
                 setSelectedOrgUnits([]);
-                setAllowMultipleOrgUnits(false);
                 return;
             }
 
@@ -238,8 +240,6 @@ export const TemplateSelector = ({
 
             const customTemplate = customTemplates.find(t => t.id === templateId);
             const templateType: TemplateType = customTemplate ? "custom" : "generated";
-
-            setAllowMultipleOrgUnits(customTemplate?.allowMultipleOrgUnits ?? false);
 
             const teiFilter =
                 templateType === "custom" && type === "trackerPrograms" && customTemplate?.filters?.teiFilters;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** #869dupqz2 https://app.clickup.com/t/869dupqz2

### :memo: Implementation

- Add hidden `allowMultipleOrgUnits` opt-in on custom templates. When set, custom dataSet templates allow multi-select in the org unit picker (previously forced single-select).
- Add hidden `orgUnitSort: "ALPHABETICAL"` opt-in. When set, `DownloadTemplateUseCase` orders the exported data entries by each org unit's ancestor-name path — pre-order (parent before children), siblings alphabetical — matching the org unit tree. `displayName` rides the existing `getElement` fetch, so there is no extra API call.

### :fire: Notes for the reviewer
TJK dev server template: `CUSTOM R2 Report on SAM Treatment -  Pediatric Wards/Hospitals (Monthly) V2`

### :video_camera: Screenshots/Screen capture

<img width="1472" height="714" alt="image" src="https://github.com/user-attachments/assets/cd8358b2-33e9-4dcb-a272-861e93101bec" />

### :bookmark_tabs: Others

Enable per template with:

```json
"allowMultipleOrgUnits": true,
"orgUnitSort": "ALPHABETICAL"
```
