### PR TITLE
[Feature]: add includeMetadataCodes flag for Metadata Code column

### DIFF
--- a/src/data/TemplateWebRepository.ts
+++ b/src/data/TemplateWebRepository.ts
@@ -41,6 +41,7 @@ export class TemplateWebRepository implements TemplateRepository {
                           : {}),
                       ...(importCustomization ? { importCustomization: importCustomization.bind(customTemplate) } : {}),
                       generateMetadata: customTemplate.generateMetadata ?? false,
+                      includeMetadataCodes: customTemplate.includeMetadataCodes ?? false,
                   }
                 : template;
         });

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -68,6 +68,7 @@ export interface GeneratedTemplate extends BaseTemplate {
     type: "generated";
     rowOffset: number;
     generateMetadata?: boolean;
+    includeMetadataCodes?: boolean;
 }
 
 export interface DownloadCustomizationOptions {
@@ -87,6 +88,7 @@ export interface ImportCustomizationOptions {
 export interface CustomTemplateWithUrl extends BaseTemplate {
     type: "custom";
     generateMetadata?: boolean;
+    includeMetadataCodes?: boolean;
     url: string;
     description: string;
     fixedOrgUnit?: CellRef;

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -135,6 +135,7 @@ export class DownloadTemplateUseCase implements UseCase {
                 useCodesForMetadata,
                 orgUnitShortName: useShortNameInOrgUnit,
                 maxTeiRows,
+                includeMetadataCodes: template.includeMetadataCodes ?? false,
             });
 
             const workbook = await sheetBuilder.generate();

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -1,0 +1,124 @@
+import { getCompositionRoot } from "../CompositionRoot";
+import { GeneratedTemplate } from "../domain/entities/Template";
+import Settings from "../webapp/logic/settings";
+import { SheetBuilder, SheetBuilderParams } from "../webapp/logic/sheetBuilder";
+import { Workbook } from "../webapp/logic/Workbook";
+import { initializeMockServer } from "./mocks/server";
+
+const metadataSheetName = "Metadata";
+const codeColumn = "H";
+const dataElement1 = { id: "DE_1", code: "CODE_DE1" };
+const dataElement2 = { id: "DE_2", code: "CODE_DE2" };
+
+const { api } = initializeMockServer();
+const compositionRoot = getCompositionRoot({
+    appConfig: { appKey: "bulk-load", storage: "dataStore" },
+    dhisInstance: { type: "local", url: api.baseUrl },
+    mockApi: api,
+});
+
+function buildElementMetadata(): Map<string, unknown> {
+    return new Map<string, unknown>([
+        ["CC_DEFAULT", { id: "CC_DEFAULT", type: "categoryCombos", code: "default", categories: [] }],
+        [
+            dataElement1.id,
+            {
+                id: dataElement1.id,
+                type: "dataElements",
+                code: dataElement1.code,
+                name: "Data element 1",
+                valueType: "TEXT",
+                categoryCombo: { id: "CC_DEFAULT" },
+            },
+        ],
+        [
+            dataElement2.id,
+            {
+                id: dataElement2.id,
+                type: "dataElements",
+                code: dataElement2.code,
+                name: "Data element 2",
+                valueType: "TEXT",
+                categoryCombo: { id: "CC_DEFAULT" },
+            },
+        ],
+    ]);
+}
+
+function buildTemplate(): GeneratedTemplate {
+    return {
+        type: "generated",
+        id: "TEMPLATE_ID",
+        name: "Test template",
+        rowOffset: 1,
+        styleSources: [],
+        dataFormId: { type: "value", id: "ds1" },
+        dataFormType: { type: "value", id: "dataSets" },
+    };
+}
+
+function buildParams(settings: Settings, includeMetadataCodes: boolean): SheetBuilderParams {
+    const elementMetadata = buildElementMetadata();
+
+    return {
+        element: {
+            id: "ds1",
+            type: "dataSets",
+            displayName: "Test DataSet",
+            formType: "DEFAULT",
+            periodType: "Monthly",
+            categoryCombo: { id: "CC_DEFAULT" },
+            dataSetElements: [],
+            sections: [],
+            attributeValues: [],
+        },
+        metadata: {},
+        elementMetadata,
+        organisationUnits: [],
+        rawMetadata: {
+            dataElements: [Array.from(elementMetadata.values())[1], Array.from(elementMetadata.values())[2]],
+            categoryOptionCombos: [],
+            optionSets: [],
+            programStageDataElements: [],
+            programTrackedEntityAttributes: [],
+        },
+        language: "en",
+        template: buildTemplate(),
+        settings,
+        downloadRelationships: false,
+        splitDataEntryTabsBySection: false,
+        useCodesForMetadata: false,
+        orgUnitShortName: false,
+        includeMetadataCodes,
+    };
+}
+
+function getMetadataSheetCellValue(workbook: Workbook, cellRef: string): unknown {
+    return workbook.xworkbook.sheet(metadataSheetName).cell(cellRef).value();
+}
+
+describe("SheetBuilder", () => {
+    let settings: Settings;
+
+    beforeAll(async () => {
+        settings = await Settings.build(api, compositionRoot);
+    });
+
+    describe("Metadata sheet Code column", () => {
+        it("adds a Code header and writes item codes when includeMetadataCodes is true", async () => {
+            const workbook = await new SheetBuilder(buildParams(settings, true)).generate();
+
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toEqual("Code");
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toEqual(dataElement1.code);
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toEqual(dataElement2.code);
+        });
+
+        it("does not write a Code header or values when includeMetadataCodes is false", async () => {
+            const workbook = await new SheetBuilder(buildParams(settings, false)).generate();
+
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toBeUndefined();
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toBeUndefined();
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toBeUndefined();
+        });
+    });
+});

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -17,31 +17,29 @@ const compositionRoot = getCompositionRoot({
     mockApi: api,
 });
 
+const dataElement1Metadata = {
+    id: dataElement1.id,
+    type: "dataElements",
+    code: dataElement1.code,
+    name: "Data element 1",
+    valueType: "TEXT",
+    categoryCombo: { id: "CC_DEFAULT" },
+};
+
+const dataElement2Metadata = {
+    id: dataElement2.id,
+    type: "dataElements",
+    code: dataElement2.code,
+    name: "Data element 2",
+    valueType: "TEXT",
+    categoryCombo: { id: "CC_DEFAULT" },
+};
+
 function buildElementMetadata(): Map<string, unknown> {
     return new Map<string, unknown>([
         ["CC_DEFAULT", { id: "CC_DEFAULT", type: "categoryCombos", code: "default", categories: [] }],
-        [
-            dataElement1.id,
-            {
-                id: dataElement1.id,
-                type: "dataElements",
-                code: dataElement1.code,
-                name: "Data element 1",
-                valueType: "TEXT",
-                categoryCombo: { id: "CC_DEFAULT" },
-            },
-        ],
-        [
-            dataElement2.id,
-            {
-                id: dataElement2.id,
-                type: "dataElements",
-                code: dataElement2.code,
-                name: "Data element 2",
-                valueType: "TEXT",
-                categoryCombo: { id: "CC_DEFAULT" },
-            },
-        ],
+        [dataElement1.id, dataElement1Metadata],
+        [dataElement2.id, dataElement2Metadata],
     ]);
 }
 
@@ -76,7 +74,7 @@ function buildParams(settings: Settings, includeMetadataCodes: boolean): SheetBu
         elementMetadata,
         organisationUnits: [],
         rawMetadata: {
-            dataElements: [Array.from(elementMetadata.values())[1], Array.from(elementMetadata.values())[2]],
+            dataElements: [dataElement1Metadata, dataElement2Metadata],
             categoryOptionCombos: [],
             optionSets: [],
             programStageDataElements: [],

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -55,6 +55,7 @@ export interface SheetBuilderParams {
     useCodesForMetadata: boolean;
     orgUnitShortName: boolean;
     maxTeiRows?: number;
+    includeMetadataCodes?: boolean;
 }
 
 export class SheetBuilder {
@@ -736,6 +737,12 @@ export class SheetBuilder {
             .cell(1, 7, 2, 7, true)
             .string(i18n.t("Metadata version", { lng: this.builder.language }))
             .style(baseStyle);
+        if (this.builder.includeMetadataCodes) {
+            metadataSheet
+                .cell(1, 8, 2, 8, true)
+                .string(i18n.t("Code", { lng: this.builder.language }))
+                .style(baseStyle);
+        }
 
         let rowId = 3;
 
@@ -763,6 +770,9 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 5).string(optionSetName ?? "");
             metadataSheet.cell(rowId, 6).string(options ?? "");
             metadataSheet.cell(rowId, 7).string(`${item.version ?? ""}`);
+            if (this.builder.includeMetadataCodes) {
+                metadataSheet.cell(rowId, 8).string(item.code ?? "");
+            }
 
             if (name !== undefined) {
                 workbook.definedNameCollection.addDefinedName({

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -42,6 +42,7 @@ export interface SheetBuilderParams {
         id: string;
         displayName: string;
         translations: any;
+        code?: string;
     }[];
     rawMetadata: any;
     startDate?: Moment;
@@ -789,6 +790,9 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 1).string(orgUnit.id !== undefined ? orgUnit.id : "");
             metadataSheet.cell(rowId, 2).string("organisationUnit");
             metadataSheet.cell(rowId, 3).string(name ?? "");
+            if (this.builder.includeMetadataCodes) {
+                metadataSheet.cell(rowId, 8).string(orgUnit.code ?? "");
+            }
 
             if (name !== undefined)
                 workbook.definedNameCollection.addDefinedName({


### PR DESCRIPTION
### :pushpin: References

* **Issue:** #869dg8vj6

### :memo: Implementation

- Add an `includeMetadataCodes` flag to the template model (`Template`, `TemplateWebRepository`, `DownloadTemplateUseCase`).
- When enabled, `sheetBuilder` writes a **Code** column in the Metadata sheet, filled with each item's DHIS2 code (data elements, options, category options, org units, …).
- Unit tests covering the Code column on/off in `sheetBuilder.spec.ts`.

### :fire: Notes for the reviewer
- No behavioural change unless `includeMetadataCodes` is set on a template, the Code column is opt-in.

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others
