### PR TITLE
[Feature]: regenerate-metadata CLI (refresh Metadata sheet from DHIS2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,33 @@ npx ts-node src/scripts/import-multiple-files.ts \
     --results-path="/path/to/folder/for/json_results" \
     file1.xlsx file2.xlsx
 ```
+
+### Regenerate template metadata (from DHIS2)
+
+You can use the script `regenerate-metadata.ts` to refresh **only** the Metadata
+sheet of an existing template from fresh DHIS2 metadata, leaving every other sheet
+(custom form, dropdowns, VBA) untouched:
+
+```bash
+yarn regenerate-metadata \
+    --dhis2-url="https://play.dhis2.org" \
+    --auth="user:pass" \
+    --input=template.xlsm \
+    --output=template.regenerated.xlsm \
+    --form-id=U6z7eJniNfL \
+    --form-type=trackerPrograms \
+    --include-codes
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `--dhis2-url` / `-u` | yes | DHIS2 base URL (auth can be embedded here or via `--auth`). |
+| `--auth` / `-a` | — | `"username:password"` (special characters are handled). |
+| `--input` / `-i` | yes | Path to the input template (`.xlsm`/`.xlsx`). |
+| `--output` / `-o` | yes | Path where the regenerated template is written. |
+| `--form-id` | yes | DHIS2 program/dataSet id whose metadata is used. |
+| `--form-type` | — | `trackerPrograms` \| `programs` \| `dataSets` (default `trackerPrograms`). |
+| `--language` | — | Metadata name language (default `en`). |
+| `--include-codes` | — | Write the Code column in the Metadata sheet (default off). |
+| `--use-codes` | — | Use item codes instead of names for org units, data elements, options… (default off). |
+| `--org-unit-short-name` | — | Use each org unit's short name instead of its regular name (default off). |

--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ yarn regenerate-metadata \
 | `--include-codes` | — | Write the Code column in the Metadata sheet (default off). |
 | `--use-codes` | — | Use item codes instead of names for org units, data elements, options… (default off). |
 | `--org-unit-short-name` | — | Use each org unit's short name instead of its regular name (default off). |
+
+The same operation is available in the app, under Settings → Maintenance → Regenerate template metadata.

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-11-19T17:15:26.356Z\n"
-"PO-Revision-Date: 2025-11-19T17:15:26.356Z\n"
+"POT-Creation-Date: 2026-07-29T04:19:07.056Z\n"
+"PO-Revision-Date: 2026-07-29T04:19:07.056Z\n"
 
 msgid "Events - Create/update"
 msgstr ""
@@ -101,6 +101,11 @@ msgid "Cannot read data form id"
 msgstr ""
 
 msgid "Program or DataSet not found in instance"
+msgstr ""
+
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template "
+"and that your session is still active."
 msgstr ""
 
 msgid "Case Registration Date"
@@ -346,6 +351,80 @@ msgstr ""
 msgid "Items older than {{period}}"
 msgstr ""
 
+msgid "File cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during file cleanup"
+msgstr ""
+
+msgid "History cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during history cleanup"
+msgstr ""
+
+msgid "Regenerate template metadata"
+msgstr ""
+
+msgid "Maintenance"
+msgstr ""
+
+msgid "File cleanup"
+msgstr ""
+
+msgid ""
+"Remove files older than the selected period. History entries will be kept "
+"but the files will be unaccessible"
+msgstr ""
+
+msgid "Cleaning up files..."
+msgstr ""
+
+msgid "Confirm File Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all files older than the selected period? "
+"This action cannot be undone. History entries will be kept but the files "
+"will be inaccessible."
+msgstr ""
+
+msgid "Remove files older than"
+msgstr ""
+
+msgid "Clean up files"
+msgstr ""
+
+msgid "History cleanup"
+msgstr ""
+
+msgid ""
+"Remove history entries and their documents older than the selected period. "
+"This action cannot be undone"
+msgstr ""
+
+msgid "Cleaning up history..."
+msgstr ""
+
+msgid "Confirm History Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all history entries and their documents "
+"older than the selected period? This action cannot be undone."
+msgstr ""
+
+msgid "Remove history entries older than"
+msgstr ""
+
+msgid "Clean up history"
+msgstr ""
+
+msgid ""
+"Refresh the Metadata sheet of an existing template file with current DHIS2 "
+"metadata"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr ""
 
@@ -381,16 +460,42 @@ msgstr ""
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "File cleanup completed successfully"
+msgid "Only .xlsx and .xlsm template files are accepted"
 msgstr ""
 
-msgid "An error occurred during file cleanup"
+msgid "Unsupported file extension for template"
 msgstr ""
 
-msgid "History cleanup completed successfully"
+msgid "Regenerating metadata..."
 msgstr ""
 
-msgid "An error occurred during history cleanup"
+msgid "Metadata regenerated"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Drag and drop the template file to regenerate"
+msgstr ""
+
+msgid "Template"
+msgstr ""
+
+msgid "Data Form Type"
+msgstr ""
+
+msgid "Include the Code column in the Metadata sheet"
+msgstr ""
+
+msgid "Use codes instead of names for metadata items"
+msgstr ""
+
+msgid "Use the short name of organisation units"
+msgstr ""
+
+msgid ""
+"The Metadata sheet will be re-protected with the standard Bulk Load sheet "
+"password. All other sheets and the macros are left untouched."
 msgstr ""
 
 msgid "Select Organisation Units on template generation"
@@ -508,60 +613,6 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-msgid "Maintenance"
-msgstr ""
-
-msgid "File cleanup"
-msgstr ""
-
-msgid ""
-"Remove files older than the selected period. History entries will be kept "
-"but the files will be unaccessible"
-msgstr ""
-
-msgid "Cleaning up files..."
-msgstr ""
-
-msgid "Confirm File Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all files older than the selected period? "
-"This action cannot be undone. History entries will be kept but the files "
-"will be inaccessible."
-msgstr ""
-
-msgid "Remove files older than"
-msgstr ""
-
-msgid "Clean up files"
-msgstr ""
-
-msgid "History cleanup"
-msgstr ""
-
-msgid ""
-"Remove history entries and their documents older than the selected period. "
-"This action cannot be undone"
-msgstr ""
-
-msgid "Cleaning up history..."
-msgstr ""
-
-msgid "Confirm History Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all history entries and their documents "
-"older than the selected period? This action cannot be undone."
-msgstr ""
-
-msgid "Remove history entries older than"
-msgstr ""
-
-msgid "Clean up history"
-msgstr ""
-
 msgid "Edit custom template"
 msgstr ""
 
@@ -639,9 +690,6 @@ msgstr ""
 msgid "Cannot determine file extension for template"
 msgstr ""
 
-msgid "Unsupported file extension for template"
-msgstr ""
-
 msgid "Cannot download spreadsheet for template"
 msgstr ""
 
@@ -649,9 +697,6 @@ msgid "Name"
 msgstr ""
 
 msgid "Description"
-msgstr ""
-
-msgid "Data Form Type"
 msgstr ""
 
 msgid "Type"
@@ -976,9 +1021,6 @@ msgid "Select organisation unit to populate data"
 msgstr ""
 
 msgid "Select available organisation units to include in the template"
-msgstr ""
-
-msgid "Template"
 msgstr ""
 
 msgid "Data Model"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-07-29T04:43:44.097Z\n"
-"PO-Revision-Date: 2026-07-29T04:43:44.097Z\n"
+"POT-Creation-Date: 2026-07-29T11:52:52.301Z\n"
+"PO-Revision-Date: 2026-07-29T11:52:52.301Z\n"
 
 msgid "Events - Create/update"
 msgstr ""
@@ -120,15 +120,15 @@ msgstr ""
 msgid "Found in {{locations}} of the Excel file"
 msgstr ""
 
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template "
+"and that your session is still active."
+msgstr ""
+
 msgid "Cannot read data form id"
 msgstr ""
 
 msgid "Program or DataSet not found in instance"
-msgstr ""
-
-msgid ""
-"Could not identify this template. Check the file is a Bulk Load template "
-"and that your session is still active."
 msgstr ""
 
 msgid "Case Registration Date"
@@ -483,18 +483,6 @@ msgstr ""
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "Only .xlsx and .xlsm template files are accepted"
-msgstr ""
-
-msgid "Unsupported file extension for template"
-msgstr ""
-
-msgid "Regenerating metadata..."
-msgstr ""
-
-msgid "Metadata regenerated"
-msgstr ""
-
 msgid "Regenerate"
 msgstr ""
 
@@ -711,6 +699,9 @@ msgid "Are you sure you want to remove the selected templates"
 msgstr ""
 
 msgid "Cannot determine file extension for template"
+msgstr ""
+
+msgid "Unsupported file extension for template"
 msgstr ""
 
 msgid "Cannot download spreadsheet for template"
@@ -1201,6 +1192,15 @@ msgid "Error loading history entries"
 msgstr ""
 
 msgid "Error loading import details"
+msgstr ""
+
+msgid "Only .xlsx and .xlsm template files are accepted"
+msgstr ""
+
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
 msgstr ""
 
 msgid "Error deleting data values"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2026-07-29T04:43:44.097Z\n"
+"POT-Creation-Date: 2026-07-29T11:52:52.301Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -132,16 +132,16 @@ msgstr ""
 msgid "Found in {{locations}} of the Excel file"
 msgstr ""
 
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
+
 msgid "Cannot read data form id"
 msgstr "No se pueden leer los datos del formulario id"
 
 msgid "Program or DataSet not found in instance"
 msgstr "No se encontraron el programa o el set de datos en la instancia"
-
-msgid ""
-"Could not identify this template. Check the file is a Bulk Load template and "
-"that your session is still active."
-msgstr ""
 
 msgid "Case Registration Date"
 msgstr ""
@@ -527,19 +527,6 @@ msgstr "Buscar elementos de datos o atributos"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "Only .xlsx and .xlsm template files are accepted"
-msgstr ""
-
-msgid "Unsupported file extension for template"
-msgstr ""
-
-#, fuzzy
-msgid "Regenerating metadata..."
-msgstr "Leyendo datos..."
-
-msgid "Metadata regenerated"
-msgstr ""
-
 msgid "Regenerate"
 msgstr ""
 
@@ -767,6 +754,9 @@ msgid "Are you sure you want to remove the selected templates"
 msgstr "Esta seguro que quiere borrar las plantillas seleccionadas"
 
 msgid "Cannot determine file extension for template"
+msgstr ""
+
+msgid "Unsupported file extension for template"
 msgstr ""
 
 msgid "Cannot download spreadsheet for template"
@@ -1261,6 +1251,15 @@ msgid "Error loading history entries"
 msgstr ""
 
 msgid "Error loading import details"
+msgstr ""
+
+msgid "Only .xlsx and .xlsm template files are accepted"
+msgstr ""
+
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
 msgstr ""
 
 msgid "Error deleting data values"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2025-11-19T17:15:26.356Z\n"
+"POT-Creation-Date: 2026-07-29T04:19:07.056Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -114,6 +114,11 @@ msgstr "No se pueden leer los datos del formulario id"
 
 msgid "Program or DataSet not found in instance"
 msgstr "No se encontraron el programa o el set de datos en la instancia"
+
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
 
 msgid "Case Registration Date"
 msgstr ""
@@ -387,6 +392,80 @@ msgstr "Programa"
 msgid "Items older than {{period}}"
 msgstr ""
 
+msgid "File cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during file cleanup"
+msgstr ""
+
+msgid "History cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during history cleanup"
+msgstr ""
+
+msgid "Regenerate template metadata"
+msgstr ""
+
+msgid "Maintenance"
+msgstr ""
+
+msgid "File cleanup"
+msgstr ""
+
+msgid ""
+"Remove files older than the selected period. History entries will be kept "
+"but the files will be unaccessible"
+msgstr ""
+
+msgid "Cleaning up files..."
+msgstr ""
+
+msgid "Confirm File Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all files older than the selected period? "
+"This action cannot be undone. History entries will be kept but the files "
+"will be inaccessible."
+msgstr ""
+
+msgid "Remove files older than"
+msgstr ""
+
+msgid "Clean up files"
+msgstr ""
+
+msgid "History cleanup"
+msgstr ""
+
+msgid ""
+"Remove history entries and their documents older than the selected period. "
+"This action cannot be undone"
+msgstr ""
+
+msgid "Cleaning up history..."
+msgstr ""
+
+msgid "Confirm History Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all history entries and their documents "
+"older than the selected period? This action cannot be undone."
+msgstr ""
+
+msgid "Remove history entries older than"
+msgstr ""
+
+msgid "Clean up history"
+msgstr ""
+
+msgid ""
+"Refresh the Metadata sheet of an existing template file with current DHIS2 "
+"metadata"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Acceso a la generación de plantillas"
 
@@ -425,19 +504,43 @@ msgstr "Buscar elementos de datos o atributos"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "File cleanup completed successfully"
+msgid "Only .xlsx and .xlsm template files are accepted"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during file cleanup"
-msgstr "Ha ocurrido un error mientras se guardaba el tema"
-
-msgid "History cleanup completed successfully"
+msgid "Unsupported file extension for template"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during history cleanup"
-msgstr "Ha ocurrido un error mientras se guardaba el tema"
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Drag and drop the template file to regenerate"
+msgstr ""
+
+msgid "Template"
+msgstr "Plantilla"
+
+msgid "Data Form Type"
+msgstr ""
+
+msgid "Include the Code column in the Metadata sheet"
+msgstr ""
+
+msgid "Use codes instead of names for metadata items"
+msgstr ""
+
+msgid "Use the short name of organisation units"
+msgstr ""
+
+msgid ""
+"The Metadata sheet will be re-protected with the standard Bulk Load sheet "
+"password. All other sheets and the macros are left untouched."
+msgstr ""
 
 msgid "Select Organisation Units on template generation"
 msgstr "Mostrar unidades organizativas durante la generación de la plantilla"
@@ -561,65 +664,6 @@ msgstr ""
 msgid "Permissions"
 msgstr "Permisos"
 
-#, fuzzy
-msgid "Maintenance"
-msgstr "Migrar la instancia"
-
-msgid "File cleanup"
-msgstr ""
-
-msgid ""
-"Remove files older than the selected period. History entries will be kept "
-"but the files will be unaccessible"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up files..."
-msgstr "Leyendo archivo..."
-
-msgid "Confirm File Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all files older than the selected period? "
-"This action cannot be undone. History entries will be kept but the files "
-"will be inaccessible."
-msgstr ""
-
-msgid "Remove files older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up files"
-msgstr "No se puede leer el archivo"
-
-msgid "History cleanup"
-msgstr ""
-
-msgid ""
-"Remove history entries and their documents older than the selected period. "
-"This action cannot be undone"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up history..."
-msgstr "Leyendo archivo..."
-
-msgid "Confirm History Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all history entries and their documents "
-"older than the selected period? This action cannot be undone."
-msgstr ""
-
-msgid "Remove history entries older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up history"
-msgstr "No se puede leer el archivo"
-
 msgid "Edit custom template"
 msgstr "Editar plantilla personalizada"
 
@@ -700,9 +744,6 @@ msgstr "Esta seguro que quiere borrar las plantillas seleccionadas"
 msgid "Cannot determine file extension for template"
 msgstr ""
 
-msgid "Unsupported file extension for template"
-msgstr ""
-
 msgid "Cannot download spreadsheet for template"
 msgstr ""
 
@@ -711,9 +752,6 @@ msgstr "Nombre"
 
 msgid "Description"
 msgstr "Descripción"
-
-msgid "Data Form Type"
-msgstr ""
 
 msgid "Type"
 msgstr "Tipo"
@@ -1031,16 +1069,15 @@ msgid "Synchronization Results"
 msgstr "Resultados de la sincronización"
 
 msgid "Selected template has unsupported period type: {{periodType}}"
-msgstr "La plantilla seleccionada tiene el tipo de período no soportado: {{periodType}}"
+msgstr ""
+"La plantilla seleccionada tiene el tipo de período no soportado: "
+"{{periodType}}"
 
 msgid "Select organisation unit to populate data"
 msgstr "Seleccione la unidad de organización para rellenar los datos"
 
 msgid "Select available organisation units to include in the template"
 msgstr "Seleccione las unidades organizativas para añadir a la plantilla"
-
-msgid "Template"
-msgstr "Plantilla"
 
 msgid "Data Model"
 msgstr "Modelo de Datos"
@@ -1427,19 +1464,30 @@ msgid ""
 "All data values in the spreadsheet will be imported to the system, but any "
 "data that was existing for such organisation unit and periods in the system "
 "will be deleted first, so none will be kept before doing the import."
-msgstr "Todos los valores de la hoja de cálculo se importarán al sistema, pero cualquier dato existente para dicha unidad organizativa y periodos se eliminará primero, por lo que no se conservará nada antes de realizar la importación."
+msgstr ""
+"Todos los valores de la hoja de cálculo se importarán al sistema, pero "
+"cualquier dato existente para dicha unidad organizativa y periodos se "
+"eliminará primero, por lo que no se conservará nada antes de realizar la "
+"importación."
 
 msgid ""
 "Import only new data values, without updating nor deleting any existing one. "
 "Only values in the spreadsheet that do not currently exist in the system "
 "will be imported"
-msgstr "Importar solo valores de datos nuevos, sin actualizar ni eliminar los existentes. Solo se importarán los valores de la hoja de cálculo que no existan actualmente en el sistema."
+msgstr ""
+"Importar solo valores de datos nuevos, sin actualizar ni eliminar los "
+"existentes. Solo se importarán los valores de la hoja de cálculo que no "
+"existan actualmente en el sistema."
 
 msgid ""
 "Import new data values and also update existing ones. All data values in the "
 "spreadsheet will be imported to the system, but other data values present in "
 "the system that are not provided in the spreadsheet will be kept."
-msgstr "Importar nuevos valores de datos y actualizar los existentes. Todos los valores de la hoja de cálculo se importarán al sistema, pero se mantendrán los demás valores presentes en el sistema que no figuren en la hoja de cálculo."
+msgstr ""
+"Importar nuevos valores de datos y actualizar los existentes. Todos los "
+"valores de la hoja de cálculo se importarán al sistema, pero se mantendrán "
+"los demás valores presentes en el sistema que no figuren en la hoja de "
+"cálculo."
 
 msgid "Warning: Your upload may result in the generation of duplicates"
 msgstr "Alerta: Su importación puede generar duplicados"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2026-07-29T04:43:44.097Z\n"
+"POT-Creation-Date: 2026-07-29T11:52:52.301Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -126,16 +126,16 @@ msgstr ""
 msgid "Found in {{locations}} of the Excel file"
 msgstr ""
 
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
+
 msgid "Cannot read data form id"
 msgstr ""
 
 msgid "Program or DataSet not found in instance"
 msgstr "Programme ou DataSet pas trouvé dans l'instance"
-
-msgid ""
-"Could not identify this template. Check the file is a Bulk Load template and "
-"that your session is still active."
-msgstr ""
 
 msgid "Case Registration Date"
 msgstr ""
@@ -512,19 +512,6 @@ msgstr ""
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "Only .xlsx and .xlsm template files are accepted"
-msgstr ""
-
-msgid "Unsupported file extension for template"
-msgstr ""
-
-#, fuzzy
-msgid "Regenerating metadata..."
-msgstr "Lecture des données ..."
-
-msgid "Metadata regenerated"
-msgstr ""
-
 msgid "Regenerate"
 msgstr ""
 
@@ -760,6 +747,9 @@ msgid "Are you sure you want to remove the selected templates"
 msgstr "Voulez-vous vraiment supprimer les thèmes sélectionnés"
 
 msgid "Cannot determine file extension for template"
+msgstr ""
+
+msgid "Unsupported file extension for template"
 msgstr ""
 
 msgid "Cannot download spreadsheet for template"
@@ -1282,6 +1272,15 @@ msgid "Error loading history entries"
 msgstr ""
 
 msgid "Error loading import details"
+msgstr ""
+
+msgid "Only .xlsx and .xlsm template files are accepted"
+msgstr ""
+
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
 msgstr ""
 
 msgid "Error deleting data values"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load App\n"
-"POT-Creation-Date: 2025-11-19T17:15:26.356Z\n"
+"POT-Creation-Date: 2026-07-29T04:19:07.056Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -108,6 +108,11 @@ msgstr ""
 
 msgid "Program or DataSet not found in instance"
 msgstr "Programme ou DataSet pas trouvé dans l'instance"
+
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
 
 msgid "Case Registration Date"
 msgstr ""
@@ -374,6 +379,80 @@ msgstr "Programme"
 msgid "Items older than {{period}}"
 msgstr ""
 
+msgid "File cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during file cleanup"
+msgstr ""
+
+msgid "History cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during history cleanup"
+msgstr ""
+
+msgid "Regenerate template metadata"
+msgstr ""
+
+msgid "Maintenance"
+msgstr ""
+
+msgid "File cleanup"
+msgstr ""
+
+msgid ""
+"Remove files older than the selected period. History entries will be kept "
+"but the files will be unaccessible"
+msgstr ""
+
+msgid "Cleaning up files..."
+msgstr ""
+
+msgid "Confirm File Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all files older than the selected period? "
+"This action cannot be undone. History entries will be kept but the files "
+"will be inaccessible."
+msgstr ""
+
+msgid "Remove files older than"
+msgstr ""
+
+msgid "Clean up files"
+msgstr ""
+
+msgid "History cleanup"
+msgstr ""
+
+msgid ""
+"Remove history entries and their documents older than the selected period. "
+"This action cannot be undone"
+msgstr ""
+
+msgid "Cleaning up history..."
+msgstr ""
+
+msgid "Confirm History Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all history entries and their documents "
+"older than the selected period? This action cannot be undone."
+msgstr ""
+
+msgid "Remove history entries older than"
+msgstr ""
+
+msgid "Clean up history"
+msgstr ""
+
+msgid ""
+"Refresh the Metadata sheet of an existing template file with current DHIS2 "
+"metadata"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Accès à la génération de modèles"
 
@@ -410,19 +489,43 @@ msgstr ""
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "File cleanup completed successfully"
+msgid "Only .xlsx and .xlsm template files are accepted"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during file cleanup"
-msgstr "Une erreur s'est produite lors de l'enregistrement du thème"
-
-msgid "History cleanup completed successfully"
+msgid "Unsupported file extension for template"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during history cleanup"
-msgstr "Une erreur s'est produite lors de l'enregistrement du thème"
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Drag and drop the template file to regenerate"
+msgstr ""
+
+msgid "Template"
+msgstr "Modèle"
+
+msgid "Data Form Type"
+msgstr ""
+
+msgid "Include the Code column in the Metadata sheet"
+msgstr ""
+
+msgid "Use codes instead of names for metadata items"
+msgstr ""
+
+msgid "Use the short name of organisation units"
+msgstr ""
+
+msgid ""
+"The Metadata sheet will be re-protected with the standard Bulk Load sheet "
+"password. All other sheets and the macros are left untouched."
+msgstr ""
 
 msgid "Select Organisation Units on template generation"
 msgstr "Sélectionnez les unités d'organisation lors de la génération du modèle"
@@ -545,64 +648,6 @@ msgstr ""
 msgid "Permissions"
 msgstr "Autorisations"
 
-msgid "Maintenance"
-msgstr ""
-
-msgid "File cleanup"
-msgstr ""
-
-msgid ""
-"Remove files older than the selected period. History entries will be kept "
-"but the files will be unaccessible"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up files..."
-msgstr "Lecture du fichier en cours ..."
-
-msgid "Confirm File Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all files older than the selected period? "
-"This action cannot be undone. History entries will be kept but the files "
-"will be inaccessible."
-msgstr ""
-
-msgid "Remove files older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up files"
-msgstr "Le fichier ne peut pas être lu"
-
-msgid "History cleanup"
-msgstr ""
-
-msgid ""
-"Remove history entries and their documents older than the selected period. "
-"This action cannot be undone"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up history..."
-msgstr "Lecture du fichier en cours ..."
-
-msgid "Confirm History Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all history entries and their documents "
-"older than the selected period? This action cannot be undone."
-msgstr ""
-
-msgid "Remove history entries older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up history"
-msgstr "Le fichier ne peut pas être lu"
-
 #, fuzzy
 msgid "Edit custom template"
 msgstr "Modèle"
@@ -692,9 +737,6 @@ msgstr "Voulez-vous vraiment supprimer les thèmes sélectionnés"
 msgid "Cannot determine file extension for template"
 msgstr ""
 
-msgid "Unsupported file extension for template"
-msgstr ""
-
 msgid "Cannot download spreadsheet for template"
 msgstr ""
 
@@ -702,9 +744,6 @@ msgid "Name"
 msgstr "Nom"
 
 msgid "Description"
-msgstr ""
-
-msgid "Data Form Type"
 msgstr ""
 
 msgid "Type"
@@ -1050,16 +1089,14 @@ msgid "Synchronization Results"
 msgstr ""
 
 msgid "Selected template has unsupported period type: {{periodType}}"
-msgstr "Modèle sélectionné avec un type de période non supporté: {{periodType}}"
+msgstr ""
+"Modèle sélectionné avec un type de période non supporté: {{periodType}}"
 
 msgid "Select organisation unit to populate data"
 msgstr ""
 
 msgid "Select available organisation units to include in the template"
 msgstr "Sélectionnez les unités d'organisation à inclure dans le modèle"
-
-msgid "Template"
-msgstr "Modèle"
 
 msgid "Data Model"
 msgstr "Modèle de données"
@@ -1451,16 +1488,18 @@ msgid ""
 "will be deleted first, so none will be kept before doing the import."
 msgstr ""
 "Toutes les données de la feuille de calcul seront importées dans le système,"
-"mais les données existantes pour ces unités d'organisation et ces périodes seront d'abord supprimées"
-"; aucune donnée existante ne sera donc conservée avant l'importation."
+"mais les données existantes pour ces unités d'organisation et ces périodes "
+"seront d'abord supprimées; aucune donnée existante ne sera donc conservée "
+"avant l'importation."
 
 msgid ""
 "Import only new data values, without updating nor deleting any existing one. "
 "Only values in the spreadsheet that do not currently exist in the system "
 "will be imported"
 msgstr ""
-"Importer uniquement les nouvelles valeurs, sans mettre à jour ni supprimer les données existantes."
-"Seules les valeurs de la feuille de calcul qui n'existent pas encore dans le système seront importées."
+"Importer uniquement les nouvelles valeurs, sans mettre à jour ni supprimer "
+"les données existantes.Seules les valeurs de la feuille de calcul qui "
+"n'existent pas encore dans le système seront importées."
 
 msgid ""
 "Import new data values and also update existing ones. All data values in the "
@@ -1468,8 +1507,9 @@ msgid ""
 "the system that are not provided in the spreadsheet will be kept."
 msgstr ""
 "Importer les nouvelles valeurs et mettre à jour les valeurs existantes."
-"Toutes les données de la feuille de calcul seront importées,"
-"mais les autres valeurs présentes dans le système et absentes de la feuille de calcul seront conservées."
+"Toutes les données de la feuille de calcul seront importées,mais les autres "
+"valeurs présentes dans le système et absentes de la feuille de calcul seront "
+"conservées."
 
 msgid "Warning: Your upload may result in the generation of duplicates"
 msgstr ""

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2025-11-19T17:15:26.356Z\n"
+"POT-Creation-Date: 2026-07-29T04:19:07.056Z\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -116,6 +116,11 @@ msgstr "Não é possível ler os dados do formulário de identificação"
 
 msgid "Program or DataSet not found in instance"
 msgstr "Programa ou DataSet não encontrado na instância"
+
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
 
 msgid "Case Registration Date"
 msgstr "Data de registo do caso"
@@ -393,6 +398,80 @@ msgstr "Programa"
 msgid "Items older than {{period}}"
 msgstr ""
 
+msgid "File cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during file cleanup"
+msgstr ""
+
+msgid "History cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during history cleanup"
+msgstr ""
+
+msgid "Regenerate template metadata"
+msgstr ""
+
+msgid "Maintenance"
+msgstr ""
+
+msgid "File cleanup"
+msgstr ""
+
+msgid ""
+"Remove files older than the selected period. History entries will be kept "
+"but the files will be unaccessible"
+msgstr ""
+
+msgid "Cleaning up files..."
+msgstr ""
+
+msgid "Confirm File Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all files older than the selected period? "
+"This action cannot be undone. History entries will be kept but the files "
+"will be inaccessible."
+msgstr ""
+
+msgid "Remove files older than"
+msgstr ""
+
+msgid "Clean up files"
+msgstr ""
+
+msgid "History cleanup"
+msgstr ""
+
+msgid ""
+"Remove history entries and their documents older than the selected period. "
+"This action cannot be undone"
+msgstr ""
+
+msgid "Cleaning up history..."
+msgstr ""
+
+msgid "Confirm History Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all history entries and their documents "
+"older than the selected period? This action cannot be undone."
+msgstr ""
+
+msgid "Remove history entries older than"
+msgstr ""
+
+msgid "Clean up history"
+msgstr ""
+
+msgid ""
+"Refresh the Metadata sheet of an existing template file with current DHIS2 "
+"metadata"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Acesso à geração de planilhas"
 
@@ -431,19 +510,43 @@ msgstr "Pesquisar elementos de dados ou atributos"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "File cleanup completed successfully"
+msgid "Only .xlsx and .xlsm template files are accepted"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during file cleanup"
-msgstr "Ocorreu um erro ao salvar o tema"
-
-msgid "History cleanup completed successfully"
+msgid "Unsupported file extension for template"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during history cleanup"
-msgstr "Ocorreu um erro ao salvar o tema"
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Drag and drop the template file to regenerate"
+msgstr ""
+
+msgid "Template"
+msgstr "Modelo"
+
+msgid "Data Form Type"
+msgstr ""
+
+msgid "Include the Code column in the Metadata sheet"
+msgstr ""
+
+msgid "Use codes instead of names for metadata items"
+msgstr ""
+
+msgid "Use the short name of organisation units"
+msgstr ""
+
+msgid ""
+"The Metadata sheet will be re-protected with the standard Bulk Load sheet "
+"password. All other sheets and the macros are left untouched."
+msgstr ""
 
 msgid "Select Organisation Units on template generation"
 msgstr "Selecione unidades organizacionais na geração de planilhas"
@@ -567,65 +670,6 @@ msgid "Permissions"
 msgstr "Permissões"
 
 #, fuzzy
-msgid "Maintenance"
-msgstr "Migrar instância"
-
-msgid "File cleanup"
-msgstr ""
-
-msgid ""
-"Remove files older than the selected period. History entries will be kept "
-"but the files will be unaccessible"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up files..."
-msgstr "Lendo arquivo ..."
-
-msgid "Confirm File Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all files older than the selected period? "
-"This action cannot be undone. History entries will be kept but the files "
-"will be inaccessible."
-msgstr ""
-
-msgid "Remove files older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up files"
-msgstr "Não é possível ler o arquivo"
-
-msgid "History cleanup"
-msgstr ""
-
-msgid ""
-"Remove history entries and their documents older than the selected period. "
-"This action cannot be undone"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up history..."
-msgstr "Lendo arquivo ..."
-
-msgid "Confirm History Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all history entries and their documents "
-"older than the selected period? This action cannot be undone."
-msgstr ""
-
-msgid "Remove history entries older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up history"
-msgstr "Não é possível ler o arquivo"
-
-#, fuzzy
 msgid "Edit custom template"
 msgstr "Modelo"
 
@@ -714,9 +758,6 @@ msgstr "Tem certeza de que deseja excluir os temas selecionados"
 msgid "Cannot determine file extension for template"
 msgstr ""
 
-msgid "Unsupported file extension for template"
-msgstr ""
-
 msgid "Cannot download spreadsheet for template"
 msgstr ""
 
@@ -725,9 +766,6 @@ msgstr "Nome"
 
 msgid "Description"
 msgstr "Descrição"
-
-msgid "Data Form Type"
-msgstr ""
 
 msgid "Type"
 msgstr "Tipo"
@@ -1093,9 +1131,6 @@ msgstr "Selecione a unidade da organização para preencher os dados"
 
 msgid "Select available organisation units to include in the template"
 msgstr "Selecione as unidades organizacionais para incluir na planilha"
-
-msgid "Template"
-msgstr "Modelo"
 
 msgid "Data Model"
 msgstr "Modelo de dados"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2026-07-29T04:43:44.097Z\n"
+"POT-Creation-Date: 2026-07-29T11:52:52.301Z\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -134,16 +134,16 @@ msgstr ""
 msgid "Found in {{locations}} of the Excel file"
 msgstr ""
 
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
+
 msgid "Cannot read data form id"
 msgstr "Não é possível ler os dados do formulário de identificação"
 
 msgid "Program or DataSet not found in instance"
 msgstr "Programa ou DataSet não encontrado na instância"
-
-msgid ""
-"Could not identify this template. Check the file is a Bulk Load template and "
-"that your session is still active."
-msgstr ""
 
 msgid "Case Registration Date"
 msgstr "Data de registo do caso"
@@ -533,19 +533,6 @@ msgstr "Pesquisar elementos de dados ou atributos"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "Only .xlsx and .xlsm template files are accepted"
-msgstr ""
-
-msgid "Unsupported file extension for template"
-msgstr ""
-
-#, fuzzy
-msgid "Regenerating metadata..."
-msgstr "Lendo dados ..."
-
-msgid "Metadata regenerated"
-msgstr ""
-
 msgid "Regenerate"
 msgstr ""
 
@@ -781,6 +768,9 @@ msgid "Are you sure you want to remove the selected templates"
 msgstr "Tem certeza de que deseja excluir os temas selecionados"
 
 msgid "Cannot determine file extension for template"
+msgstr ""
+
+msgid "Unsupported file extension for template"
 msgstr ""
 
 msgid "Cannot download spreadsheet for template"
@@ -1314,6 +1304,15 @@ msgid "Error loading history entries"
 msgstr ""
 
 msgid "Error loading import details"
+msgstr ""
+
+msgid "Only .xlsx and .xlsm template files are accepted"
+msgstr ""
+
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
 msgstr ""
 
 msgid "Error deleting data values"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2026-07-29T04:43:44.097Z\n"
+"POT-Creation-Date: 2026-07-29T11:52:52.301Z\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -138,16 +138,16 @@ msgstr ""
 msgid "Found in {{locations}} of the Excel file"
 msgstr ""
 
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
+
 msgid "Cannot read data form id"
 msgstr "Невозможно прочитать данные формы id"
 
 msgid "Program or DataSet not found in instance"
 msgstr "Программа или набор данных не найдены в экземпляре"
-
-msgid ""
-"Could not identify this template. Check the file is a Bulk Load template and "
-"that your session is still active."
-msgstr ""
 
 msgid "Case Registration Date"
 msgstr "Дата регистрации дела"
@@ -537,19 +537,6 @@ msgstr "Поиск элементов или атрибутов данных"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "Only .xlsx and .xlsm template files are accepted"
-msgstr ""
-
-msgid "Unsupported file extension for template"
-msgstr ""
-
-#, fuzzy
-msgid "Regenerating metadata..."
-msgstr "Чтение данных..."
-
-msgid "Metadata regenerated"
-msgstr ""
-
 msgid "Regenerate"
 msgstr ""
 
@@ -786,6 +773,9 @@ msgid "Are you sure you want to remove the selected templates"
 msgstr "Вы уверены, что хотите удалить выбранные темы"
 
 msgid "Cannot determine file extension for template"
+msgstr ""
+
+msgid "Unsupported file extension for template"
 msgstr ""
 
 msgid "Cannot download spreadsheet for template"
@@ -1321,6 +1311,15 @@ msgid "Error loading history entries"
 msgstr ""
 
 msgid "Error loading import details"
+msgstr ""
+
+msgid "Only .xlsx and .xlsm template files are accepted"
+msgstr ""
+
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
 msgstr ""
 
 msgid "Error deleting data values"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bulk Load\n"
-"POT-Creation-Date: 2025-11-19T17:15:26.356Z\n"
+"POT-Creation-Date: 2026-07-29T04:19:07.056Z\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -118,6 +118,11 @@ msgstr "Невозможно прочитать данные формы id"
 
 msgid "Program or DataSet not found in instance"
 msgstr "Программа или набор данных не найдены в экземпляре"
+
+msgid ""
+"Could not identify this template. Check the file is a Bulk Load template and "
+"that your session is still active."
+msgstr ""
 
 msgid "Case Registration Date"
 msgstr "Дата регистрации дела"
@@ -394,6 +399,80 @@ msgstr "Программа"
 msgid "Items older than {{period}}"
 msgstr ""
 
+msgid "File cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during file cleanup"
+msgstr ""
+
+msgid "History cleanup completed successfully"
+msgstr ""
+
+msgid "An error occurred during history cleanup"
+msgstr ""
+
+msgid "Regenerate template metadata"
+msgstr ""
+
+msgid "Maintenance"
+msgstr ""
+
+msgid "File cleanup"
+msgstr ""
+
+msgid ""
+"Remove files older than the selected period. History entries will be kept "
+"but the files will be unaccessible"
+msgstr ""
+
+msgid "Cleaning up files..."
+msgstr ""
+
+msgid "Confirm File Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all files older than the selected period? "
+"This action cannot be undone. History entries will be kept but the files "
+"will be inaccessible."
+msgstr ""
+
+msgid "Remove files older than"
+msgstr ""
+
+msgid "Clean up files"
+msgstr ""
+
+msgid "History cleanup"
+msgstr ""
+
+msgid ""
+"Remove history entries and their documents older than the selected period. "
+"This action cannot be undone"
+msgstr ""
+
+msgid "Cleaning up history..."
+msgstr ""
+
+msgid "Confirm History Cleanup"
+msgstr ""
+
+msgid ""
+"Are you sure you want to remove all history entries and their documents "
+"older than the selected period? This action cannot be undone."
+msgstr ""
+
+msgid "Remove history entries older than"
+msgstr ""
+
+msgid "Clean up history"
+msgstr ""
+
+msgid ""
+"Refresh the Metadata sheet of an existing template file with current DHIS2 "
+"metadata"
+msgstr ""
+
 msgid "Access to Template Generation"
 msgstr "Доступ к генерации шаблонов"
 
@@ -433,19 +512,43 @@ msgstr "Поиск элементов или атрибутов данных"
 msgid "Populate events for every Tracked Entity Instance (TEI)"
 msgstr ""
 
-msgid "File cleanup completed successfully"
+msgid "Only .xlsx and .xlsm template files are accepted"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during file cleanup"
-msgstr "Возникла ошибка при сохранении темы"
-
-msgid "History cleanup completed successfully"
+msgid "Unsupported file extension for template"
 msgstr ""
 
-#, fuzzy
-msgid "An error occurred during history cleanup"
-msgstr "Возникла ошибка при сохранении темы"
+msgid "Regenerating metadata..."
+msgstr ""
+
+msgid "Metadata regenerated"
+msgstr ""
+
+msgid "Regenerate"
+msgstr ""
+
+msgid "Drag and drop the template file to regenerate"
+msgstr ""
+
+msgid "Template"
+msgstr "Шаблон"
+
+msgid "Data Form Type"
+msgstr ""
+
+msgid "Include the Code column in the Metadata sheet"
+msgstr ""
+
+msgid "Use codes instead of names for metadata items"
+msgstr ""
+
+msgid "Use the short name of organisation units"
+msgstr ""
+
+msgid ""
+"The Metadata sheet will be re-protected with the standard Bulk Load sheet "
+"password. All other sheets and the macros are left untouched."
+msgstr ""
 
 msgid "Select Organisation Units on template generation"
 msgstr "Выберите организационные единицы при создании шаблона"
@@ -568,65 +671,6 @@ msgid "Permissions"
 msgstr "Разрешения"
 
 #, fuzzy
-msgid "Maintenance"
-msgstr "Мигрировать экземпляр"
-
-msgid "File cleanup"
-msgstr ""
-
-msgid ""
-"Remove files older than the selected period. History entries will be kept "
-"but the files will be unaccessible"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up files..."
-msgstr "Чтение файла..."
-
-msgid "Confirm File Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all files older than the selected period? "
-"This action cannot be undone. History entries will be kept but the files "
-"will be inaccessible."
-msgstr ""
-
-msgid "Remove files older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up files"
-msgstr "Невозможно прочитать файл"
-
-msgid "History cleanup"
-msgstr ""
-
-msgid ""
-"Remove history entries and their documents older than the selected period. "
-"This action cannot be undone"
-msgstr ""
-
-#, fuzzy
-msgid "Cleaning up history..."
-msgstr "Чтение файла..."
-
-msgid "Confirm History Cleanup"
-msgstr ""
-
-msgid ""
-"Are you sure you want to remove all history entries and their documents "
-"older than the selected period? This action cannot be undone."
-msgstr ""
-
-msgid "Remove history entries older than"
-msgstr ""
-
-#, fuzzy
-msgid "Clean up history"
-msgstr "Невозможно прочитать файл"
-
-#, fuzzy
 msgid "Edit custom template"
 msgstr "Шаблон"
 
@@ -717,9 +761,6 @@ msgstr "Вы уверены, что хотите удалить выбранны
 msgid "Cannot determine file extension for template"
 msgstr ""
 
-msgid "Unsupported file extension for template"
-msgstr ""
-
 msgid "Cannot download spreadsheet for template"
 msgstr ""
 
@@ -728,9 +769,6 @@ msgstr "Имя"
 
 msgid "Description"
 msgstr "Описание"
-
-msgid "Data Form Type"
-msgstr ""
 
 msgid "Type"
 msgstr "Тип"
@@ -1096,9 +1134,6 @@ msgstr "Выберите организационную единицу для з
 
 msgid "Select available organisation units to include in the template"
 msgstr "Выберите доступные подразделения организации для включения в шаблон"
-
-msgid "Template"
-msgstr "Шаблон"
 
 msgid "Data Model"
 msgstr "Модель данных"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp && tsc && vite build --outDir=build && yarn run manifest && cp -r i18n icon.png build",
         "build": "VITE_DHIS2_BASE_URL='' VITE_DHIS2_AUTH='' yarn build-folder && rm -f $npm_package_name.zip && cd build && zip --quiet -r ../$npm_package_name.zip *",
         "test": "yarn test-unit",
+        "regenerate-metadata": "ts-node --transpile-only --project src/scripts/tsconfig.json src/scripts/regenerate-metadata.ts",
         "test-unit": "vitest run --reporter=basic",
         "test-unit-watch": "vitest watch",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@dhis2/d2-ui-core": "7.3.3",
         "@dhis2/ui-core": "6.24.0",
         "@dhis2/ui-widgets": "6.24.0",
-        "@eyeseetea/d2-api": "1.20.0",
+        "@eyeseetea/d2-api": "1.21.0",
         "@eyeseetea/d2-ui-components": "2.12.0",
         "@eyeseetea/feedback-component": "0.3.0",
         "@eyeseetea/xlsx-populate": "4.3.2-beta.1",

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -21,6 +21,7 @@ import { DeleteCustomTemplateUseCase } from "./domain/usecases/DeleteCustomTempl
 import { DeleteThemeUseCase } from "./domain/usecases/DeleteThemeUseCase";
 import { DownloadTemplateUseCase } from "./domain/usecases/DownloadTemplateUseCase";
 import { RegenerateTemplateMetadataUseCase } from "./domain/usecases/RegenerateTemplateMetadataUseCase";
+import { ResolveTemplateFromFileUseCase } from "./domain/usecases/ResolveTemplateFromFileUseCase";
 import { GetCustomTemplatesUseCase } from "./domain/usecases/GetCustomTemplatesUseCase";
 import { GetDataFormsForGenerationUseCase } from "./domain/usecases/GetDataFormsForGenerationUseCase";
 import { GetDataFormsUseCase } from "./domain/usecases/GetDataFormsUseCase";
@@ -127,6 +128,7 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi, importSou
                 dataElementDisaggregationsMappingRepository
             ),
             regenerateMetadata: new RegenerateTemplateMetadataUseCase(),
+            resolveFromFile: new ResolveTemplateFromFileUseCase(instance, templateManager, excelReader),
             list: new ListDataFormsUseCase(instance),
             getDataFormsForGeneration: new GetDataFormsForGenerationUseCase(instance),
             get: new GetDataFormsUseCase(instance),

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -20,6 +20,7 @@ import { ConvertDataPackageUseCase } from "./domain/usecases/ConvertDataPackageU
 import { DeleteCustomTemplateUseCase } from "./domain/usecases/DeleteCustomTemplateUseCase";
 import { DeleteThemeUseCase } from "./domain/usecases/DeleteThemeUseCase";
 import { DownloadTemplateUseCase } from "./domain/usecases/DownloadTemplateUseCase";
+import { RegenerateTemplateMetadataUseCase } from "./domain/usecases/RegenerateTemplateMetadataUseCase";
 import { GetCustomTemplatesUseCase } from "./domain/usecases/GetCustomTemplatesUseCase";
 import { GetDataFormsForGenerationUseCase } from "./domain/usecases/GetDataFormsForGenerationUseCase";
 import { GetDataFormsUseCase } from "./domain/usecases/GetDataFormsUseCase";
@@ -125,6 +126,7 @@ export function getCompositionRoot({ appConfig, dhisInstance, mockApi, importSou
                 documentRepository,
                 dataElementDisaggregationsMappingRepository
             ),
+            regenerateMetadata: new RegenerateTemplateMetadataUseCase(),
             list: new ListDataFormsUseCase(instance),
             getDataFormsForGeneration: new GetDataFormsForGenerationUseCase(instance),
             get: new GetDataFormsUseCase(instance),

--- a/src/data/TemplateWebRepository.ts
+++ b/src/data/TemplateWebRepository.ts
@@ -41,6 +41,7 @@ export class TemplateWebRepository implements TemplateRepository {
                           : {}),
                       ...(importCustomization ? { importCustomization: importCustomization.bind(customTemplate) } : {}),
                       generateMetadata: customTemplate.generateMetadata ?? false,
+                      includeMetadataCodes: customTemplate.includeMetadataCodes ?? false,
                   }
                 : template;
         });

--- a/src/domain/entities/Template.ts
+++ b/src/domain/entities/Template.ts
@@ -68,6 +68,7 @@ export interface GeneratedTemplate extends BaseTemplate {
     type: "generated";
     rowOffset: number;
     generateMetadata?: boolean;
+    includeMetadataCodes?: boolean;
 }
 
 export interface DownloadCustomizationOptions {
@@ -87,6 +88,7 @@ export interface ImportCustomizationOptions {
 export interface CustomTemplateWithUrl extends BaseTemplate {
     type: "custom";
     generateMetadata?: boolean;
+    includeMetadataCodes?: boolean;
     url: string;
     description: string;
     fixedOrgUnit?: CellRef;

--- a/src/domain/usecases/AnalyzeTemplateUseCase.ts
+++ b/src/domain/usecases/AnalyzeTemplateUseCase.ts
@@ -1,6 +1,7 @@
 import { UseCase } from "../../CompositionRoot";
 import i18n from "../../utils/i18n";
 import { getExcelOrThrow } from "../../utils/files";
+import { cleanFormula } from "../../utils/string";
 import { ExcelReader } from "../helpers/ExcelReader";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
@@ -59,5 +60,3 @@ export class AnalyzeTemplateUseCase implements UseCase {
         return { custom: true, dataForm, dataValues, orgUnits, file };
     }
 }
-
-const cleanFormula = (string: string) => (string.startsWith("_") ? string.substr(1) : string);

--- a/src/domain/usecases/AnalyzeTemplateUseCase.ts
+++ b/src/domain/usecases/AnalyzeTemplateUseCase.ts
@@ -1,12 +1,11 @@
 import { UseCase } from "../../CompositionRoot";
-import i18n from "../../utils/i18n";
 import { getExcelOrThrow } from "../../utils/files";
-import { cleanFormula } from "../../utils/string";
 import { ExcelReader } from "../helpers/ExcelReader";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
 import { TemplateRepository } from "../repositories/TemplateRepository";
 import { DataElementDisaggregationsMappingRepository } from "../repositories/DataElementDisaggregationsMappingRepository";
+import { getDataFormFromTemplate, loadTemplateFromExcel } from "./utils/templates";
 
 export class AnalyzeTemplateUseCase implements UseCase {
     constructor(
@@ -19,24 +18,18 @@ export class AnalyzeTemplateUseCase implements UseCase {
     public async execute(file: File) {
         const excelFile = await getExcelOrThrow(file);
 
-        const templateId = await this.excelRepository.loadTemplate({ type: "file", file: excelFile });
-        const template = await this.templateRepository.getTemplate(templateId);
+        const { templateId, template } = await loadTemplateFromExcel(
+            this.templateRepository,
+            this.excelRepository,
+            excelFile
+        );
 
-        const dataFormId1 = await this.excelRepository.readCell(templateId, template.dataFormId, {
-            formula: true,
-        });
-        const dataFormId2 = await this.excelRepository.readCell(templateId, template.dataFormId);
-        const dataFormId = dataFormId1 || dataFormId2;
-
-        if (!dataFormId || typeof dataFormId !== "string") {
-            throw new Error(i18n.t("Cannot read data form id"));
-        }
-
-        const [dataForm] = await this.instanceRepository.getDataForms({
-            ids: [cleanFormula(dataFormId)],
-        });
-
-        if (!dataForm) throw new Error(i18n.t("Program or DataSet not found in instance"));
+        const dataForm = await getDataFormFromTemplate(
+            this.instanceRepository,
+            this.excelRepository,
+            templateId,
+            template
+        );
 
         const orgUnits = await this.instanceRepository.getDataFormOrgUnits(dataForm.type, dataForm.id);
 

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -264,7 +264,7 @@ export class DownloadTemplateUseCase implements UseCase {
     }
 }
 
-async function getElement(api: D2Api, type: DataFormType, id: string) {
+export async function getElement(api: D2Api, type: DataFormType, id: string) {
     const endpoint = type === dataFormTypeMap.dataSets ? "dataSets" : "programs";
     const fields = [
         "id",
@@ -288,7 +288,7 @@ async function getElement(api: D2Api, type: DataFormType, id: string) {
     return { ...response, type };
 }
 
-async function getElementMetadata({
+export async function getElementMetadata({
     element,
     api,
     orgUnitIds,

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -135,6 +135,7 @@ export class DownloadTemplateUseCase implements UseCase {
                 useCodesForMetadata,
                 orgUnitShortName: useShortNameInOrgUnit,
                 maxTeiRows,
+                includeMetadataCodes: template.includeMetadataCodes ?? false,
             });
 
             const workbook = await sheetBuilder.generate();

--- a/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
+++ b/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
@@ -9,21 +9,28 @@ import { getElement, getElementMetadata } from "./DownloadTemplateUseCase";
 export type RegenerateTemplateMetadataOptions = {
     type: DataFormType;
     id: string;
-    /** base64 contents of the input template whose Metadata sheet will be regenerated */
+    /** base64-encoded input template */
     fileContents: string;
     settings: Settings;
     language: string;
+    includeMetadataCodes: boolean;
+    useCodesForMetadata: boolean;
+    orgUnitShortName: boolean;
 };
 
-/**
- * Regenerates ONLY the Metadata sheet of an existing custom template from fresh DHIS2
- * metadata (with the Code column), leaving every other sheet (custom form, dropdowns, VBA)
- * untouched. Reusable from both the CLI script and the web app.
- */
+/** Regenerates only the Metadata sheet of a template, leaving all other sheets untouched. */
 export class RegenerateTemplateMetadataUseCase implements UseCase {
-    /** Returns the regenerated template as a base64 string (works in both Node and the browser). */
     public async execute(api: D2Api, options: RegenerateTemplateMetadataOptions): Promise<string> {
-        const { type, id, fileContents, settings, language } = options;
+        const {
+            type,
+            id,
+            fileContents,
+            settings,
+            language,
+            includeMetadataCodes,
+            useCodesForMetadata,
+            orgUnitShortName,
+        } = options;
 
         const element = await getElement(api, type, id);
         const orgUnitIds = element.organisationUnits.map((orgUnit: { id: string }) => orgUnit.id);
@@ -35,11 +42,10 @@ export class RegenerateTemplateMetadataUseCase implements UseCase {
             orgUnitIds,
             startDate: undefined,
             endDate: undefined,
-            orgUnitShortName: false,
+            orgUnitShortName,
         });
 
-        // Minimal template: SheetBuilder only reads template.type for rowOffset, and
-        // generateMetadataOnly never touches the form sheets.
+        // Minimal template: generateMetadataOnly only needs type/id, not the form sheets.
         const template: GeneratedTemplate = {
             type: "generated",
             id: "regenerate-metadata",
@@ -57,9 +63,9 @@ export class RegenerateTemplateMetadataUseCase implements UseCase {
             settings,
             downloadRelationships: false,
             splitDataEntryTabsBySection: false,
-            useCodesForMetadata: false,
-            orgUnitShortName: false,
-            includeMetadataCodes: true,
+            useCodesForMetadata,
+            orgUnitShortName,
+            includeMetadataCodes,
         });
 
         const workbook = await sheetBuilder.generateMetadataOnly(fileContents);

--- a/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
+++ b/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
@@ -1,5 +1,8 @@
 import { UseCase } from "../../CompositionRoot";
 import { D2Api } from "../../types/d2-api";
+// TODO: Settings and SheetBuilder live in webapp/logic, so this use case breaks the
+// domain → presentation dependency rule. Moving them to domain requires a wider
+// refactor (shared by other use cases) and is tracked as its own task.
 import Settings from "../../webapp/logic/settings";
 import { SheetBuilder } from "../../webapp/logic/sheetBuilder";
 import { DataFormType } from "../entities/DataForm";

--- a/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
+++ b/src/domain/usecases/RegenerateTemplateMetadataUseCase.ts
@@ -1,0 +1,68 @@
+import { UseCase } from "../../CompositionRoot";
+import { D2Api } from "../../types/d2-api";
+import Settings from "../../webapp/logic/settings";
+import { SheetBuilder } from "../../webapp/logic/sheetBuilder";
+import { DataFormType } from "../entities/DataForm";
+import { GeneratedTemplate } from "../entities/Template";
+import { getElement, getElementMetadata } from "./DownloadTemplateUseCase";
+
+export type RegenerateTemplateMetadataOptions = {
+    type: DataFormType;
+    id: string;
+    /** base64 contents of the input template whose Metadata sheet will be regenerated */
+    fileContents: string;
+    settings: Settings;
+    language: string;
+};
+
+/**
+ * Regenerates ONLY the Metadata sheet of an existing custom template from fresh DHIS2
+ * metadata (with the Code column), leaving every other sheet (custom form, dropdowns, VBA)
+ * untouched. Reusable from both the CLI script and the web app.
+ */
+export class RegenerateTemplateMetadataUseCase implements UseCase {
+    /** Returns the regenerated template as a base64 string (works in both Node and the browser). */
+    public async execute(api: D2Api, options: RegenerateTemplateMetadataOptions): Promise<string> {
+        const { type, id, fileContents, settings, language } = options;
+
+        const element = await getElement(api, type, id);
+        const orgUnitIds = element.organisationUnits.map((orgUnit: { id: string }) => orgUnit.id);
+
+        const result = await getElementMetadata({
+            api,
+            element,
+            downloadRelationships: false,
+            orgUnitIds,
+            startDate: undefined,
+            endDate: undefined,
+            orgUnitShortName: false,
+        });
+
+        // Minimal template: SheetBuilder only reads template.type for rowOffset, and
+        // generateMetadataOnly never touches the form sheets.
+        const template: GeneratedTemplate = {
+            type: "generated",
+            id: "regenerate-metadata",
+            name: "Regenerate metadata",
+            rowOffset: 0,
+            styleSources: [],
+            dataFormId: { type: "value", id },
+            dataFormType: { type: "value", id: type },
+        };
+
+        const sheetBuilder = new SheetBuilder({
+            ...result,
+            language,
+            template,
+            settings,
+            downloadRelationships: false,
+            splitDataEntryTabsBySection: false,
+            useCodesForMetadata: false,
+            orgUnitShortName: false,
+            includeMetadataCodes: true,
+        });
+
+        const workbook = await sheetBuilder.generateMetadataOnly(fileContents);
+        return workbook.writeToBase64();
+    }
+}

--- a/src/domain/usecases/ResolveTemplateFromFileUseCase.ts
+++ b/src/domain/usecases/ResolveTemplateFromFileUseCase.ts
@@ -1,0 +1,58 @@
+import { UseCase } from "../../CompositionRoot";
+import i18n from "../../utils/i18n";
+import { getExcelOrThrow } from "../../utils/files";
+import { cleanFormula } from "../../utils/string";
+import { DataForm } from "../entities/DataForm";
+import { Template } from "../entities/Template";
+import { ExcelRepository } from "../repositories/ExcelRepository";
+import { InstanceRepository } from "../repositories/InstanceRepository";
+import { TemplateRepository } from "../repositories/TemplateRepository";
+
+export type ResolvedTemplate = Readonly<{
+    template: Template;
+    dataForm: DataForm;
+}>;
+
+export class ResolveTemplateFromFileUseCase implements UseCase {
+    constructor(
+        private instanceRepository: InstanceRepository,
+        private templateRepository: TemplateRepository,
+        private excelRepository: ExcelRepository
+    ) {}
+
+    public async execute(file: File): Promise<ResolvedTemplate> {
+        const excelFile = await getExcelOrThrow(file);
+        const { templateId, template } = await this.resolveTemplate(excelFile);
+
+        const [dataFormIdFormula, dataFormIdValue] = await Promise.all([
+            this.excelRepository.readCell(templateId, template.dataFormId, { formula: true }),
+            this.excelRepository.readCell(templateId, template.dataFormId),
+        ]);
+        const dataFormId = dataFormIdFormula || dataFormIdValue;
+
+        if (!dataFormId || typeof dataFormId !== "string") {
+            throw new Error(i18n.t("Cannot read data form id"));
+        }
+
+        const [dataForm] = await this.instanceRepository.getDataForms({ ids: [cleanFormula(dataFormId)] });
+
+        if (!dataForm) throw new Error(i18n.t("Program or DataSet not found in instance"));
+
+        return { template, dataForm };
+    }
+
+    private async resolveTemplate(excelFile: Blob): Promise<{ templateId: string; template: Template }> {
+        try {
+            const templateId = await this.excelRepository.loadTemplate({ type: "file", file: excelFile });
+            const template = await this.templateRepository.getTemplate(templateId);
+            return { templateId, template };
+        } catch (error) {
+            console.error(error);
+            throw new Error(
+                i18n.t(
+                    "Could not identify this template. Check the file is a Bulk Load template and that your session is still active."
+                )
+            );
+        }
+    }
+}

--- a/src/domain/usecases/ResolveTemplateFromFileUseCase.ts
+++ b/src/domain/usecases/ResolveTemplateFromFileUseCase.ts
@@ -1,12 +1,12 @@
 import { UseCase } from "../../CompositionRoot";
 import i18n from "../../utils/i18n";
 import { getExcelOrThrow } from "../../utils/files";
-import { cleanFormula } from "../../utils/string";
 import { DataForm } from "../entities/DataForm";
 import { Template } from "../entities/Template";
 import { ExcelRepository } from "../repositories/ExcelRepository";
 import { InstanceRepository } from "../repositories/InstanceRepository";
 import { TemplateRepository } from "../repositories/TemplateRepository";
+import { getDataFormFromTemplate, LoadedTemplate, loadTemplateFromExcel } from "./utils/templates";
 
 export type ResolvedTemplate = Readonly<{
     template: Template;
@@ -24,28 +24,19 @@ export class ResolveTemplateFromFileUseCase implements UseCase {
         const excelFile = await getExcelOrThrow(file);
         const { templateId, template } = await this.resolveTemplate(excelFile);
 
-        const [dataFormIdFormula, dataFormIdValue] = await Promise.all([
-            this.excelRepository.readCell(templateId, template.dataFormId, { formula: true }),
-            this.excelRepository.readCell(templateId, template.dataFormId),
-        ]);
-        const dataFormId = dataFormIdFormula || dataFormIdValue;
-
-        if (!dataFormId || typeof dataFormId !== "string") {
-            throw new Error(i18n.t("Cannot read data form id"));
-        }
-
-        const [dataForm] = await this.instanceRepository.getDataForms({ ids: [cleanFormula(dataFormId)] });
-
-        if (!dataForm) throw new Error(i18n.t("Program or DataSet not found in instance"));
+        const dataForm = await getDataFormFromTemplate(
+            this.instanceRepository,
+            this.excelRepository,
+            templateId,
+            template
+        );
 
         return { template, dataForm };
     }
 
-    private async resolveTemplate(excelFile: Blob): Promise<{ templateId: string; template: Template }> {
+    private async resolveTemplate(excelFile: Blob): Promise<LoadedTemplate> {
         try {
-            const templateId = await this.excelRepository.loadTemplate({ type: "file", file: excelFile });
-            const template = await this.templateRepository.getTemplate(templateId);
-            return { templateId, template };
+            return await loadTemplateFromExcel(this.templateRepository, this.excelRepository, excelFile);
         } catch (error) {
             console.error(error);
             throw new Error(

--- a/src/domain/usecases/utils/__tests__/templates.spec.ts
+++ b/src/domain/usecases/utils/__tests__/templates.spec.ts
@@ -1,0 +1,100 @@
+import { vi } from "vitest";
+import { DataForm } from "../../../entities/DataForm";
+import { Template } from "../../../entities/Template";
+import { ExcelRepository } from "../../../repositories/ExcelRepository";
+import { InstanceRepository } from "../../../repositories/InstanceRepository";
+import { TemplateRepository } from "../../../repositories/TemplateRepository";
+import { getDataFormFromTemplate, loadTemplateFromExcel } from "../templates";
+
+const TEMPLATE_ID = "PHSM_CUSTOM_TEMPLATE";
+const DATA_FORM_ID = "U6z7eJniNfL";
+const CANNOT_READ_DATA_FORM_ID_MESSAGE = "Cannot read data form id";
+const DATA_FORM_NOT_FOUND_MESSAGE = "Program or DataSet not found in instance";
+
+const template = {
+    id: TEMPLATE_ID,
+    type: "custom",
+    name: "PHSM v7",
+    dataFormId: { type: "cell", sheet: "Data Entry", ref: "A2" },
+} as unknown as Template;
+
+const dataForm = {
+    id: DATA_FORM_ID,
+    type: "programs",
+    name: "PHSM Program",
+} as unknown as DataForm;
+
+const excelFile = new Blob([""]);
+
+function buildExcelRepository(overrides: {
+    readCellFormula?: unknown;
+    readCellValue?: unknown;
+    loadTemplate?: () => Promise<string>;
+}): ExcelRepository {
+    return {
+        loadTemplate: vi.fn(overrides.loadTemplate ?? (async () => TEMPLATE_ID)),
+        readCell: vi.fn(async (_id: string, _ref: unknown, options?: { formula?: boolean }) =>
+            options?.formula ? overrides.readCellFormula : overrides.readCellValue
+        ),
+    } as unknown as ExcelRepository;
+}
+
+function buildTemplateRepository(getTemplate?: () => Promise<Template>): TemplateRepository {
+    return { getTemplate: vi.fn(getTemplate ?? (async () => template)) } as unknown as TemplateRepository;
+}
+
+function buildInstanceRepository(dataForms: DataForm[] = [dataForm]): InstanceRepository {
+    return { getDataForms: vi.fn(async () => dataForms) } as unknown as InstanceRepository;
+}
+
+describe("loadTemplateFromExcel", () => {
+    it("loads the workbook and resolves its template", async () => {
+        const excelRepository = buildExcelRepository({});
+        const templateRepository = buildTemplateRepository();
+
+        const result = await loadTemplateFromExcel(templateRepository, excelRepository, excelFile);
+
+        expect(result).toEqual({ templateId: TEMPLATE_ID, template });
+        expect(excelRepository.loadTemplate).toHaveBeenCalledWith({ type: "file", file: excelFile });
+        expect(templateRepository.getTemplate).toHaveBeenCalledWith(TEMPLATE_ID);
+    });
+});
+
+describe("getDataFormFromTemplate", () => {
+    it("resolves the data form referenced by the template", async () => {
+        const excelRepository = buildExcelRepository({ readCellValue: DATA_FORM_ID });
+        const instanceRepository = buildInstanceRepository([dataForm]);
+
+        const result = await getDataFormFromTemplate(instanceRepository, excelRepository, TEMPLATE_ID, template);
+
+        expect(result).toEqual(dataForm);
+        expect(instanceRepository.getDataForms).toHaveBeenCalledWith({ ids: [DATA_FORM_ID] });
+    });
+
+    it("strips the leading underscore of a formula data form reference", async () => {
+        const excelRepository = buildExcelRepository({ readCellFormula: `_${DATA_FORM_ID}` });
+        const instanceRepository = buildInstanceRepository([dataForm]);
+
+        await getDataFormFromTemplate(instanceRepository, excelRepository, TEMPLATE_ID, template);
+
+        expect(instanceRepository.getDataForms).toHaveBeenCalledWith({ ids: [DATA_FORM_ID] });
+    });
+
+    it("throws when the data form id cannot be read", async () => {
+        const excelRepository = buildExcelRepository({ readCellValue: undefined });
+        const instanceRepository = buildInstanceRepository([dataForm]);
+
+        await expect(
+            getDataFormFromTemplate(instanceRepository, excelRepository, TEMPLATE_ID, template)
+        ).rejects.toThrow(CANNOT_READ_DATA_FORM_ID_MESSAGE);
+    });
+
+    it("throws when the data form is missing from the instance", async () => {
+        const excelRepository = buildExcelRepository({ readCellValue: DATA_FORM_ID });
+        const instanceRepository = buildInstanceRepository([]);
+
+        await expect(
+            getDataFormFromTemplate(instanceRepository, excelRepository, TEMPLATE_ID, template)
+        ).rejects.toThrow(DATA_FORM_NOT_FOUND_MESSAGE);
+    });
+});

--- a/src/domain/usecases/utils/templates.ts
+++ b/src/domain/usecases/utils/templates.ts
@@ -1,0 +1,42 @@
+import i18n from "../../../utils/i18n";
+import { cleanFormula } from "../../../utils/string";
+import { DataForm } from "../../entities/DataForm";
+import { Template } from "../../entities/Template";
+import { ExcelRepository } from "../../repositories/ExcelRepository";
+import { InstanceRepository } from "../../repositories/InstanceRepository";
+import { TemplateRepository } from "../../repositories/TemplateRepository";
+
+export type LoadedTemplate = Readonly<{ templateId: string; template: Template }>;
+
+export async function loadTemplateFromExcel(
+    templateRepository: TemplateRepository,
+    excelRepository: ExcelRepository,
+    excelFile: Blob
+): Promise<LoadedTemplate> {
+    const templateId = await excelRepository.loadTemplate({ type: "file", file: excelFile });
+    const template = await templateRepository.getTemplate(templateId);
+    return { templateId, template };
+}
+
+export async function getDataFormFromTemplate(
+    instanceRepository: InstanceRepository,
+    excelRepository: ExcelRepository,
+    templateId: string,
+    template: Template
+): Promise<DataForm> {
+    const [dataFormIdFormula, dataFormIdValue] = await Promise.all([
+        excelRepository.readCell(templateId, template.dataFormId, { formula: true }),
+        excelRepository.readCell(templateId, template.dataFormId),
+    ]);
+    const dataFormId = dataFormIdFormula || dataFormIdValue;
+
+    if (!dataFormId || typeof dataFormId !== "string") {
+        throw new Error(i18n.t("Cannot read data form id"));
+    }
+
+    const [dataForm] = await instanceRepository.getDataForms({ ids: [cleanFormula(dataFormId)] });
+
+    if (!dataForm) throw new Error(i18n.t("Program or DataSet not found in instance"));
+
+    return dataForm;
+}

--- a/src/scripts/regenerate-metadata.ts
+++ b/src/scripts/regenerate-metadata.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { command, run, string, option, flag } from "cmd-ts";
+import { command, run, string, option, flag, oneOf } from "cmd-ts";
 import { readFile, writeFile } from "node:fs/promises";
 
 import { D2Api } from "./../types/d2-api";
@@ -8,7 +8,7 @@ import { getCompositionRoot } from "../CompositionRoot";
 import { JsonConfig } from "../data/ConfigWebRepository";
 import { getD2APiFromInstance } from "../utils/d2-api";
 import Settings from "../webapp/logic/settings";
-import { DataFormType } from "../domain/entities/DataForm";
+import { dataFormTypeMap, dataFormTypes } from "../domain/entities/DataForm";
 
 // Embed --auth into the URL, matching how the rest of the app builds its DHIS2 instance.
 function buildDhis2Url(baseUrl: string, auth: string): string {
@@ -56,9 +56,9 @@ function main() {
                 description: "DHIS2 program/dataSet id whose metadata is used (e.g. U6z7eJniNfL)",
             }),
             formType: option({
-                type: string,
+                type: oneOf(dataFormTypes),
                 long: "form-type",
-                defaultValue: () => "trackerPrograms",
+                defaultValue: () => dataFormTypeMap.trackerPrograms,
                 description: "Data form type: trackerPrograms | programs | dataSets (default: trackerPrograms)",
             }),
             language: option({
@@ -96,7 +96,7 @@ function main() {
             console.debug(`Regenerating Metadata for ${args.input} (form ${args.formId})`);
 
             const outputBase64 = await compositionRoot.templates.regenerateMetadata(api, {
-                type: args.formType as DataFormType,
+                type: args.formType,
                 id: args.formId,
                 fileContents,
                 settings,

--- a/src/scripts/regenerate-metadata.ts
+++ b/src/scripts/regenerate-metadata.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { command, run, string, option } from "cmd-ts";
+import { command, run, string, option, flag } from "cmd-ts";
 import { readFile, writeFile } from "node:fs/promises";
 
 import { D2Api } from "./../types/d2-api";
@@ -67,6 +67,18 @@ function main() {
                 defaultValue: () => "en",
                 description: "Language for metadata names (default: en)",
             }),
+            includeCodes: flag({
+                long: "include-codes",
+                description: "Write the Code column in the Metadata sheet (default: off)",
+            }),
+            useCodes: flag({
+                long: "use-codes",
+                description: "Use codes instead of names for metadata items (default: off)",
+            }),
+            orgUnitShortName: flag({
+                long: "org-unit-short-name",
+                description: "Use each org unit's short name instead of its regular name (default: off)",
+            }),
         },
         handler: async args => {
             const url = buildDhis2Url(args.url, args.auth);
@@ -89,6 +101,9 @@ function main() {
                 fileContents,
                 settings,
                 language: args.language,
+                includeMetadataCodes: args.includeCodes,
+                useCodesForMetadata: args.useCodes,
+                orgUnitShortName: args.orgUnitShortName,
             });
 
             await writeFile(args.output, Buffer.from(outputBase64, "base64"));

--- a/src/scripts/regenerate-metadata.ts
+++ b/src/scripts/regenerate-metadata.ts
@@ -1,0 +1,100 @@
+import path from "path";
+import { command, run, string, option } from "cmd-ts";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { D2Api } from "./../types/d2-api";
+import appConfig from "../../public/app-config.json";
+import { getCompositionRoot } from "../CompositionRoot";
+import { JsonConfig } from "../data/ConfigWebRepository";
+import { getD2APiFromInstance } from "../utils/d2-api";
+import Settings from "../webapp/logic/settings";
+import { DataFormType } from "../domain/entities/DataForm";
+
+// Embed --auth into the URL, matching how the rest of the app builds its DHIS2 instance.
+function buildDhis2Url(baseUrl: string, auth: string): string {
+    if (!auth) return baseUrl;
+    const separatorIndex = auth.indexOf(":");
+    const url = new URL(baseUrl);
+    url.username = separatorIndex === -1 ? auth : auth.slice(0, separatorIndex);
+    url.password = separatorIndex === -1 ? "" : auth.slice(separatorIndex + 1);
+    return url.href;
+}
+
+function main() {
+    const cmd = command({
+        name: path.basename(__filename),
+        description: "Regenerate the Metadata sheet of a custom template from fresh DHIS2 metadata",
+        args: {
+            url: option({
+                type: string,
+                short: "u",
+                long: "dhis2-url",
+                description: "DHIS2 base URL. Example: https://play.dhis2.org (auth via --auth, or embedded here)",
+            }),
+            auth: option({
+                type: string,
+                short: "a",
+                long: "auth",
+                defaultValue: () => "",
+                description: 'DHIS2 auth as "username:password" (special characters are handled)',
+            }),
+            input: option({
+                type: string,
+                short: "i",
+                long: "input",
+                description: "Path to the input template (.xlsm/.xlsx)",
+            }),
+            output: option({
+                type: string,
+                short: "o",
+                long: "output",
+                description: "Path where the regenerated template will be written",
+            }),
+            formId: option({
+                type: string,
+                long: "form-id",
+                description: "DHIS2 program/dataSet id whose metadata is used (e.g. U6z7eJniNfL)",
+            }),
+            formType: option({
+                type: string,
+                long: "form-type",
+                defaultValue: () => "trackerPrograms",
+                description: "Data form type: trackerPrograms | programs | dataSets (default: trackerPrograms)",
+            }),
+            language: option({
+                type: string,
+                long: "language",
+                defaultValue: () => "en",
+                description: "Language for metadata names (default: en)",
+            }),
+        },
+        handler: async args => {
+            const url = buildDhis2Url(args.url, args.auth);
+            const api: D2Api = getD2APiFromInstance({ type: "local", url });
+            const compositionRoot = getCompositionRoot({
+                appConfig: appConfig as unknown as JsonConfig,
+                dhisInstance: { type: "local", url },
+                importSource: "node",
+            });
+            const settings = await Settings.build(api, compositionRoot);
+
+            const fileContents = (await readFile(args.input)).toString("base64");
+            console.debug(`Regenerating Metadata for ${args.input} (form ${args.formId})`);
+
+            const outputBase64 = await compositionRoot.templates.regenerateMetadata(api, {
+                type: args.formType as DataFormType,
+                id: args.formId,
+                fileContents,
+                settings,
+                language: args.language,
+            });
+
+            await writeFile(args.output, Buffer.from(outputBase64, "base64"));
+            console.debug(`Wrote regenerated template to ${args.output}`);
+        },
+    });
+
+    run(cmd, process.argv.slice(2));
+}
+
+main();

--- a/src/scripts/regenerate-metadata.ts
+++ b/src/scripts/regenerate-metadata.ts
@@ -76,9 +76,11 @@ function main() {
                 dhisInstance: { type: "local", url },
                 importSource: "node",
             });
-            const settings = await Settings.build(api, compositionRoot);
-
-            const fileContents = (await readFile(args.input)).toString("base64");
+            const [settings, fileBuffer] = await Promise.all([
+                Settings.build(api, compositionRoot),
+                readFile(args.input),
+            ]);
+            const fileContents = fileBuffer.toString("base64");
             console.debug(`Regenerating Metadata for ${args.input} (form ${args.formId})`);
 
             const outputBase64 = await compositionRoot.templates.regenerateMetadata(api, {

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -1,0 +1,124 @@
+import { getCompositionRoot } from "../CompositionRoot";
+import { GeneratedTemplate } from "../domain/entities/Template";
+import Settings from "../webapp/logic/settings";
+import { SheetBuilder, SheetBuilderParams } from "../webapp/logic/sheetBuilder";
+import { Workbook } from "../webapp/logic/Workbook";
+import { initializeMockServer } from "./mocks/server";
+
+const metadataSheetName = "Metadata";
+const codeColumn = "H";
+const dataElement1 = { id: "DE_1", code: "CODE_DE1" };
+const dataElement2 = { id: "DE_2", code: "CODE_DE2" };
+
+const { api } = initializeMockServer();
+const compositionRoot = getCompositionRoot({
+    appConfig: { appKey: "bulk-load", storage: "dataStore" },
+    dhisInstance: { type: "local", url: api.baseUrl },
+    mockApi: api,
+});
+
+function buildElementMetadata(): Map<string, unknown> {
+    return new Map<string, unknown>([
+        ["CC_DEFAULT", { id: "CC_DEFAULT", type: "categoryCombos", code: "default", categories: [] }],
+        [
+            dataElement1.id,
+            {
+                id: dataElement1.id,
+                type: "dataElements",
+                code: dataElement1.code,
+                name: "Data element 1",
+                valueType: "TEXT",
+                categoryCombo: { id: "CC_DEFAULT" },
+            },
+        ],
+        [
+            dataElement2.id,
+            {
+                id: dataElement2.id,
+                type: "dataElements",
+                code: dataElement2.code,
+                name: "Data element 2",
+                valueType: "TEXT",
+                categoryCombo: { id: "CC_DEFAULT" },
+            },
+        ],
+    ]);
+}
+
+function buildTemplate(): GeneratedTemplate {
+    return {
+        type: "generated",
+        id: "TEMPLATE_ID",
+        name: "Test template",
+        rowOffset: 1,
+        styleSources: [],
+        dataFormId: { type: "value", id: "ds1" },
+        dataFormType: { type: "value", id: "dataSets" },
+    };
+}
+
+function buildParams(settings: Settings, includeMetadataCodes: boolean): SheetBuilderParams {
+    const elementMetadata = buildElementMetadata();
+
+    return {
+        element: {
+            id: "ds1",
+            type: "dataSets",
+            displayName: "Test DataSet",
+            formType: "DEFAULT",
+            periodType: "Monthly",
+            categoryCombo: { id: "CC_DEFAULT" },
+            dataSetElements: [],
+            sections: [],
+            attributeValues: [],
+        },
+        metadata: {},
+        elementMetadata,
+        organisationUnits: [],
+        rawMetadata: {
+            dataElements: [Array.from(elementMetadata.values())[1], Array.from(elementMetadata.values())[2]],
+            categoryOptionCombos: [],
+            optionSets: [],
+            programStageDataElements: [],
+            programTrackedEntityAttributes: [],
+        },
+        language: "en",
+        template: buildTemplate(),
+        settings,
+        downloadRelationships: false,
+        splitDataEntryTabsBySection: false,
+        useCodesForMetadata: false,
+        orgUnitShortName: false,
+        includeMetadataCodes,
+    };
+}
+
+function getMetadataSheetCellValue(workbook: Workbook, cellRef: string): unknown {
+    return workbook.xworkbook.sheet(metadataSheetName).cell(cellRef).value();
+}
+
+describe("SheetBuilder", () => {
+    let settings: Settings;
+
+    beforeAll(async () => {
+        settings = await Settings.build(api, compositionRoot);
+    });
+
+    describe("Metadata sheet Code column", () => {
+        it("adds a Code header and writes item codes when includeMetadataCodes is true", async () => {
+            const workbook = await new SheetBuilder(buildParams(settings, true)).generate();
+
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toEqual("Code");
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toEqual(dataElement1.code);
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toEqual(dataElement2.code);
+        });
+
+        it("does not write a Code header or values when includeMetadataCodes is false", async () => {
+            const workbook = await new SheetBuilder(buildParams(settings, false)).generate();
+
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toBeUndefined();
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toBeUndefined();
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toBeUndefined();
+        });
+    });
+});

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -17,31 +17,29 @@ const compositionRoot = getCompositionRoot({
     mockApi: api,
 });
 
+const dataElement1Metadata = {
+    id: dataElement1.id,
+    type: "dataElements",
+    code: dataElement1.code,
+    name: "Data element 1",
+    valueType: "TEXT",
+    categoryCombo: { id: "CC_DEFAULT" },
+};
+
+const dataElement2Metadata = {
+    id: dataElement2.id,
+    type: "dataElements",
+    code: dataElement2.code,
+    name: "Data element 2",
+    valueType: "TEXT",
+    categoryCombo: { id: "CC_DEFAULT" },
+};
+
 function buildElementMetadata(): Map<string, unknown> {
     return new Map<string, unknown>([
         ["CC_DEFAULT", { id: "CC_DEFAULT", type: "categoryCombos", code: "default", categories: [] }],
-        [
-            dataElement1.id,
-            {
-                id: dataElement1.id,
-                type: "dataElements",
-                code: dataElement1.code,
-                name: "Data element 1",
-                valueType: "TEXT",
-                categoryCombo: { id: "CC_DEFAULT" },
-            },
-        ],
-        [
-            dataElement2.id,
-            {
-                id: dataElement2.id,
-                type: "dataElements",
-                code: dataElement2.code,
-                name: "Data element 2",
-                valueType: "TEXT",
-                categoryCombo: { id: "CC_DEFAULT" },
-            },
-        ],
+        [dataElement1.id, dataElement1Metadata],
+        [dataElement2.id, dataElement2Metadata],
     ]);
 }
 
@@ -76,7 +74,7 @@ function buildParams(settings: Settings, includeMetadataCodes: boolean): SheetBu
         elementMetadata,
         organisationUnits: [],
         rawMetadata: {
-            dataElements: [Array.from(elementMetadata.values())[1], Array.from(elementMetadata.values())[2]],
+            dataElements: [dataElement1Metadata, dataElement2Metadata],
             categoryOptionCombos: [],
             optionSets: [],
             programStageDataElements: [],

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -119,4 +119,20 @@ describe("SheetBuilder", () => {
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toBeUndefined();
         });
     });
+
+    describe("generateMetadataOnly", () => {
+        it("refreshes the Metadata sheet (with Code column) while preserving other sheets", async () => {
+            const base = await new SheetBuilder(buildParams(settings, false)).generate();
+            expect(getMetadataSheetCellValue(base, `${codeColumn}1`)).toBeUndefined(); // no codes yet
+            const inputBase64 = await base.writeToBase64();
+
+            const regenerated = await new SheetBuilder(buildParams(settings, true)).generateMetadataOnly(inputBase64);
+
+            // Metadata refreshed with the Code column
+            expect(getMetadataSheetCellValue(regenerated, `${codeColumn}1`)).toEqual("Code");
+            expect(getMetadataSheetCellValue(regenerated, `${codeColumn}4`)).toEqual(dataElement1.code);
+            // Other sheets preserved (generate() also produced a Legend sheet)
+            expect(regenerated.xworkbook.sheet("Legend")).toBeTruthy();
+        });
+    });
 });

--- a/src/test/sheetBuilder.spec.ts
+++ b/src/test/sheetBuilder.spec.ts
@@ -7,8 +7,11 @@ import { initializeMockServer } from "./mocks/server";
 
 const metadataSheetName = "Metadata";
 const codeColumn = "H";
+// Metadata sheet rows 3-5 hold the sorted CC_DEFAULT/dataElement1/dataElement2 items; org units follow.
+const orgUnitRow = 6;
 const dataElement1 = { id: "DE_1", code: "CODE_DE1" };
 const dataElement2 = { id: "DE_2", code: "CODE_DE2" };
+const orgUnit1 = { id: "OU_1", displayName: "Org unit 1", translations: [], code: "CODE_OU1" };
 
 const { api } = initializeMockServer();
 const compositionRoot = getCompositionRoot({
@@ -72,7 +75,7 @@ function buildParams(settings: Settings, includeMetadataCodes: boolean): SheetBu
         },
         metadata: {},
         elementMetadata,
-        organisationUnits: [],
+        organisationUnits: [orgUnit1],
         rawMetadata: {
             dataElements: [dataElement1Metadata, dataElement2Metadata],
             categoryOptionCombos: [],
@@ -109,6 +112,7 @@ describe("SheetBuilder", () => {
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toEqual("Code");
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toEqual(dataElement1.code);
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toEqual(dataElement2.code);
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}${orgUnitRow}`)).toEqual(orgUnit1.code);
         });
 
         it("does not write a Code header or values when includeMetadataCodes is false", async () => {
@@ -117,6 +121,7 @@ describe("SheetBuilder", () => {
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}1`)).toBeUndefined();
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}4`)).toBeUndefined();
             expect(getMetadataSheetCellValue(workbook, `${codeColumn}5`)).toBeUndefined();
+            expect(getMetadataSheetCellValue(workbook, `${codeColumn}${orgUnitRow}`)).toBeUndefined();
         });
     });
 

--- a/src/test/usecases/ResolveTemplateFromFileUseCase.spec.ts
+++ b/src/test/usecases/ResolveTemplateFromFileUseCase.spec.ts
@@ -1,0 +1,158 @@
+import { vi } from "vitest";
+import { DataForm } from "../../domain/entities/DataForm";
+import { Template } from "../../domain/entities/Template";
+import { ExcelRepository } from "../../domain/repositories/ExcelRepository";
+import { InstanceRepository } from "../../domain/repositories/InstanceRepository";
+import { TemplateRepository } from "../../domain/repositories/TemplateRepository";
+import { ResolvedTemplate, ResolveTemplateFromFileUseCase } from "../../domain/usecases/ResolveTemplateFromFileUseCase";
+
+const TEMPLATE_ID = "PHSM_CUSTOM_TEMPLATE";
+const DATA_FORM_ID = "U6z7eJniNfL";
+const COULD_NOT_IDENTIFY_MESSAGE =
+    "Could not identify this template. Check the file is a Bulk Load template and that your session is still active.";
+const MISSING_ID_ERROR_MESSAGE = "Invalid id";
+const DATASTORE_ERROR_MESSAGE = "Request failed with status code 401";
+const PARSE_ERROR_MESSAGE = "Corrupted zip: expected 4 bytes";
+const UNKNOWN_TEMPLATE_MESSAGE = `Attempt to read from invalid template ${TEMPLATE_ID}`;
+
+const template = {
+    id: TEMPLATE_ID,
+    type: "custom",
+    name: "PHSM v7",
+    dataFormId: { type: "cell", sheet: "Data Entry", ref: "A2" },
+} as unknown as Template;
+
+const dataForm = {
+    id: DATA_FORM_ID,
+    type: "programs",
+    name: "PHSM Program",
+} as unknown as DataForm;
+
+const file = new File([""], "template.xlsm");
+
+type Overrides = Readonly<{
+    loadTemplate?: () => Promise<string>;
+    getTemplate?: () => Promise<Template>;
+    readCellFormula?: unknown;
+    readCellValue?: unknown;
+    dataForms?: DataForm[];
+}>;
+
+function buildUseCase(overrides: Overrides = {}) {
+    const excelRepository = {
+        loadTemplate: vi.fn(overrides.loadTemplate ?? (async () => TEMPLATE_ID)),
+        readCell: vi.fn(async (_id: string, _ref: unknown, options?: { formula?: boolean }) =>
+            options?.formula ? overrides.readCellFormula : overrides.readCellValue
+        ),
+    } as unknown as ExcelRepository;
+
+    const templateRepository = {
+        getTemplate: vi.fn(overrides.getTemplate ?? (async () => template)),
+    } as unknown as TemplateRepository;
+
+    const instanceRepository = {
+        getDataForms: vi.fn(async () => overrides.dataForms ?? [dataForm]),
+    } as unknown as InstanceRepository;
+
+    const useCase = new ResolveTemplateFromFileUseCase(instanceRepository, templateRepository, excelRepository);
+
+    return { useCase, instanceRepository };
+}
+
+describe("ResolveTemplateFromFileUseCase", () => {
+    describe("when the file is a recognised template", () => {
+        it("returns the resolved template and data form", async () => {
+            const { useCase } = buildUseCase({ readCellValue: DATA_FORM_ID });
+
+            const result: ResolvedTemplate = await useCase.execute(file);
+
+            expect(result).toEqual({ template, dataForm });
+        });
+
+        it("strips the leading underscore of a formula data form reference", async () => {
+            const { useCase, instanceRepository } = buildUseCase({ readCellFormula: `_${DATA_FORM_ID}` });
+
+            await useCase.execute(file);
+
+            expect(instanceRepository.getDataForms).toHaveBeenCalledWith({ ids: [DATA_FORM_ID] });
+        });
+    });
+
+    describe("when the template cannot be resolved", () => {
+        async function expectSameFailureMessage(overrides: Overrides, originalError: Error) {
+            const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+            const { useCase } = buildUseCase(overrides);
+
+            await expect(useCase.execute(file)).rejects.toThrow(COULD_NOT_IDENTIFY_MESSAGE);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(originalError);
+
+            consoleErrorSpy.mockRestore();
+        }
+
+        it("shows the same message when the file carries no template id", async () => {
+            const missingIdError = new Error(MISSING_ID_ERROR_MESSAGE);
+
+            await expectSameFailureMessage(
+                {
+                    loadTemplate: async () => {
+                        throw missingIdError;
+                    },
+                },
+                missingIdError
+            );
+        });
+
+        it("shows the same message when the template id is unknown to the datastore", async () => {
+            const unknownTemplateError = new Error(UNKNOWN_TEMPLATE_MESSAGE);
+
+            await expectSameFailureMessage(
+                {
+                    getTemplate: async () => {
+                        throw unknownTemplateError;
+                    },
+                },
+                unknownTemplateError
+            );
+        });
+
+        it("shows the same message when the datastore is unreachable", async () => {
+            const datastoreError = new Error(DATASTORE_ERROR_MESSAGE);
+
+            await expectSameFailureMessage(
+                {
+                    getTemplate: async () => {
+                        throw datastoreError;
+                    },
+                },
+                datastoreError
+            );
+        });
+
+        it("shows the same message when the workbook cannot be parsed", async () => {
+            const parseError = new Error(PARSE_ERROR_MESSAGE);
+
+            await expectSameFailureMessage(
+                {
+                    loadTemplate: async () => {
+                        throw parseError;
+                    },
+                },
+                parseError
+            );
+        });
+    });
+
+    describe("when the data form cannot be resolved", () => {
+        it("reports an unreadable data form id distinctly", async () => {
+            const { useCase } = buildUseCase({ readCellValue: undefined });
+
+            await expect(useCase.execute(file)).rejects.toThrow("Cannot read data form id");
+        });
+
+        it("reports a data form missing from the instance distinctly", async () => {
+            const { useCase } = buildUseCase({ readCellValue: DATA_FORM_ID, dataForms: [] });
+
+            await expect(useCase.execute(file)).rejects.toThrow("Program or DataSet not found in instance");
+        });
+    });
+});

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -52,8 +52,9 @@ export const fromBase64 = async (uri: string, filename?: string, options?: { mim
 };
 
 export function getBlobFromBase64(contents: string): Blob {
-    const buffer = Buffer.from(contents, "base64");
-    return new Blob([buffer]);
+    const bytes = Uint8Array.from(window.atob(contents), character => character.charCodeAt(0));
+
+    return new Blob([bytes]);
 }
 
 export function isExcelFile(fileName: string): boolean {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -6,6 +6,11 @@ export function isString(value: unknown): value is string {
     return typeof value === "string";
 }
 
+// Excel defined-name references to DHIS2 ids are prefixed with an underscore (ex: `_aP6qePO2WG6`).
+export function cleanFormula(value: string): string {
+    return value.startsWith("_") ? value.substring(1) : value;
+}
+
 // XML 1.0 forbids most C0 control characters. The xlsx format is XML, so any
 // such character in a string cell breaks the file in MS Excel (LibreOffice
 // silently strips them). Preserve \t (\x09), \n (\x0A) and \r (\x0D) — the

--- a/src/webapp/components/dropzone/TemplateDropzone.tsx
+++ b/src/webapp/components/dropzone/TemplateDropzone.tsx
@@ -1,0 +1,90 @@
+import { makeStyles } from "@material-ui/core";
+import CloudDoneIcon from "@material-ui/icons/CloudDone";
+import CloudUploadIcon from "@material-ui/icons/CloudUpload";
+import React from "react";
+import Dropzone from "react-dropzone";
+
+export type TemplateDropzoneProps = {
+    accept: string[];
+    placeholder: string;
+    selectedFileName?: string;
+    onDrop: (files: File[]) => void;
+    disabled?: boolean;
+};
+
+export function TemplateDropzone(props: TemplateDropzoneProps): React.ReactElement {
+    const { accept, placeholder, selectedFileName, onDrop, disabled = false } = props;
+    const classes = useStyles();
+
+    return (
+        <Dropzone accept={accept} onDrop={onDrop} multiple={false} disabled={disabled}>
+            {({ getRootProps, getInputProps, isDragActive, isDragAccept }) => (
+                <section className={classes.dropzoneSection}>
+                    <div
+                        {...getRootProps({
+                            className: isDragActive
+                                ? `${classes.stripes} ${isDragAccept ? classes.acceptStripes : classes.rejectStripes}`
+                                : classes.dropzone,
+                        })}
+                    >
+                        <input {...getInputProps()} />
+                        <div className={classes.dropzoneTextStyle}>
+                            <p className={classes.dropzoneParagraph}>{selectedFileName ?? placeholder}</p>
+                            <br />
+                            {selectedFileName ? (
+                                <CloudDoneIcon className={classes.uploadIconSize} />
+                            ) : (
+                                <CloudUploadIcon className={classes.uploadIconSize} />
+                            )}
+                        </div>
+                    </div>
+                </section>
+            )}
+        </Dropzone>
+    );
+}
+
+const useStyles = makeStyles({
+    dropzoneTextStyle: { textAlign: "center", top: "15%", position: "relative" },
+    dropzoneParagraph: { fontSize: 20 },
+    uploadIconSize: { width: 50, height: 50, color: "#909090" },
+    dropzone: {
+        position: "relative",
+        width: "100%",
+        height: 270,
+        backgroundColor: "#f0f0f0",
+        border: "dashed",
+        borderColor: "#c8c8c8",
+        cursor: "pointer",
+    },
+    stripes: {
+        width: "100%",
+        height: 270,
+        cursor: "pointer",
+        border: "solid",
+        borderColor: "#c8c8c8",
+        "-webkit-animation": "progress 2s linear infinite !important",
+        "-moz-animation": "progress 2s linear infinite !important",
+        animation: "progress 2s linear infinite !important",
+        backgroundSize: "150% 100%",
+    },
+    acceptStripes: {
+        backgroundImage: `repeating-linear-gradient(
+            -45deg,
+            #f0f0f0,
+            #f0f0f0 25px,
+            #c8c8c8 25px,
+            #c8c8c8 50px
+        )`,
+    },
+    rejectStripes: {
+        backgroundImage: `repeating-linear-gradient(
+            -45deg,
+            #fc8785,
+            #fc8785 25px,
+            #f4231f 25px,
+            #f4231f 50px
+        )`,
+    },
+    dropzoneSection: { marginBottom: "1em" },
+});

--- a/src/webapp/components/settings/MaintenanceSection.tsx
+++ b/src/webapp/components/settings/MaintenanceSection.tsx
@@ -1,0 +1,109 @@
+import { Icon, ListItem, ListItemIcon, ListItemText, makeStyles } from "@material-ui/core";
+import React, { useCallback, useState } from "react";
+import i18n from "../../../utils/i18n";
+import { useAppContext } from "../../contexts/app-context";
+import { useMaintenanceCleanup } from "../../hooks/useMaintenanceCleanup";
+import Settings from "../../logic/settings";
+import { MaintenanceItem } from "./MaintenanceItem";
+import { RegenerateMetadataDialog } from "./RegenerateMetadataDialog";
+
+export type MaintenanceSectionProps = {
+    settings: Settings;
+};
+
+export function MaintenanceSection(props: MaintenanceSectionProps): React.ReactElement {
+    const { settings } = props;
+    const classes = useStyles();
+    const { compositionRoot } = useAppContext();
+
+    const [isRegenerateDialogVisible, setRegenerateDialogVisible] = useState(false);
+
+    const openRegenerateDialog = useCallback(() => setRegenerateDialogVisible(true), []);
+    const closeRegenerateDialog = useCallback(() => setRegenerateDialogVisible(false), []);
+
+    const uploadsMaintenance = useMaintenanceCleanup({
+        cleanupAction: async (cutoffDate: Date) => {
+            await compositionRoot.history.cleanupDocuments(cutoffDate, settings.currentUser);
+        },
+        successMessage: i18n.t("File cleanup completed successfully"),
+        errorMessage: i18n.t("An error occurred during file cleanup"),
+    });
+
+    const historyMaintenance = useMaintenanceCleanup({
+        cleanupAction: async (cutoffDate: Date) => {
+            await compositionRoot.history.cleanup(cutoffDate, settings.currentUser);
+        },
+        successMessage: i18n.t("History cleanup completed successfully"),
+        errorMessage: i18n.t("An error occurred during history cleanup"),
+    });
+
+    return (
+        <React.Fragment>
+            {isRegenerateDialogVisible && (
+                <RegenerateMetadataDialog
+                    title={i18n.t("Regenerate template metadata")}
+                    settings={settings}
+                    onClose={closeRegenerateDialog}
+                />
+            )}
+
+            <h3 className={classes.title}>{i18n.t("Maintenance")}</h3>
+
+            <MaintenanceItem
+                config={{
+                    icon: "description",
+                    primaryText: i18n.t("File cleanup"),
+                    secondaryText: i18n.t(
+                        "Remove files older than the selected period. History entries will be kept but the files will be unaccessible"
+                    ),
+                    loadingText: i18n.t("Cleaning up files..."),
+                    confirmationTitle: i18n.t("Confirm File Cleanup"),
+                    confirmationDescription: i18n.t(
+                        "Are you sure you want to remove all files older than the selected period? This action cannot be undone. History entries will be kept but the files will be inaccessible."
+                    ),
+                    periodInputLabel: i18n.t("Remove files older than"),
+                    finalConfirmationTitle: i18n.t("Confirm File Cleanup"),
+                    operationName: i18n.t("File cleanup"),
+                    saveText: i18n.t("Clean up files"),
+                }}
+                maintenance={uploadsMaintenance}
+            />
+
+            <MaintenanceItem
+                config={{
+                    icon: "history",
+                    primaryText: i18n.t("History cleanup"),
+                    secondaryText: i18n.t(
+                        "Remove history entries and their documents older than the selected period. This action cannot be undone"
+                    ),
+                    loadingText: i18n.t("Cleaning up history..."),
+                    confirmationTitle: i18n.t("Confirm History Cleanup"),
+                    confirmationDescription: i18n.t(
+                        "Are you sure you want to remove all history entries and their documents older than the selected period? This action cannot be undone."
+                    ),
+                    periodInputLabel: i18n.t("Remove history entries older than"),
+                    finalConfirmationTitle: i18n.t("Confirm History Cleanup"),
+                    operationName: i18n.t("History cleanup"),
+                    saveText: i18n.t("Clean up history"),
+                }}
+                maintenance={historyMaintenance}
+            />
+
+            <ListItem button onClick={openRegenerateDialog}>
+                <ListItemIcon>
+                    <Icon>autorenew</Icon>
+                </ListItemIcon>
+                <ListItemText
+                    primary={i18n.t("Regenerate template metadata")}
+                    secondary={i18n.t(
+                        "Refresh the Metadata sheet of an existing template file with current DHIS2 metadata"
+                    )}
+                />
+            </ListItem>
+        </React.Fragment>
+    );
+}
+
+const useStyles = makeStyles({
+    title: { marginTop: 0 },
+});

--- a/src/webapp/components/settings/RegenerateMetadataDialog.tsx
+++ b/src/webapp/components/settings/RegenerateMetadataDialog.tsx
@@ -17,17 +17,8 @@ export function RegenerateMetadataDialog(props: RegenerateMetadataDialogProps): 
     const { title, settings, onClose } = props;
     const classes = useStyles();
 
-    const {
-        resolution,
-        flags,
-        isRunning,
-        translations,
-        droppedFileName,
-        onDrop,
-        setFlag,
-        regenerate,
-        cancel,
-    } = useRegenerateMetadata({ settings, onClose });
+    const { resolution, flags, isRunning, translations, droppedFileName, onDrop, setFlag, regenerate, cancel } =
+        useRegenerateMetadata({ settings, onClose });
 
     return (
         <ConfirmationDialog

--- a/src/webapp/components/settings/RegenerateMetadataDialog.tsx
+++ b/src/webapp/components/settings/RegenerateMetadataDialog.tsx
@@ -1,21 +1,11 @@
-import { ConfirmationDialog, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { ConfirmationDialog } from "@eyeseetea/d2-ui-components";
 import { Checkbox, CircularProgress, FormControlLabel, FormGroup, makeStyles } from "@material-ui/core";
-import React, { useCallback, useMemo, useState } from "react";
-import { DataForm, getTranslations } from "../../../domain/entities/DataForm";
-import { Template } from "../../../domain/entities/Template";
-import { RegenerateTemplateMetadataOptions } from "../../../domain/usecases/RegenerateTemplateMetadataUseCase";
-import {
-    getBlobFromBase64,
-    getExtensionFile,
-    MIME_TYPES_BY_EXTENSION,
-    toBase64,
-    xlsxMimeTypes,
-} from "../../../utils/files";
+import React from "react";
+import { xlsxMimeTypes } from "../../../utils/files";
 import i18n from "../../../utils/i18n";
-import { useAppContext } from "../../contexts/app-context";
+import { useRegenerateMetadata } from "../../hooks/useRegenerateMetadata";
 import { TemplateDropzone } from "../dropzone/TemplateDropzone";
 import Settings from "../../logic/settings";
-import { downloadFile } from "../../utils/download";
 
 export type RegenerateMetadataDialogProps = {
     title: string;
@@ -23,127 +13,21 @@ export type RegenerateMetadataDialogProps = {
     onClose: () => void;
 };
 
-type ResolvedTemplate = {
-    file: File;
-    template: Template;
-    dataForm: DataForm;
-};
-
-type ResolutionState =
-    | { type: "empty" }
-    | { type: "loading" }
-    | { type: "resolved"; resolved: ResolvedTemplate }
-    | { type: "error"; message: string };
-
-type Flags = Readonly<
-    Pick<RegenerateTemplateMetadataOptions, "includeMetadataCodes" | "useCodesForMetadata" | "orgUnitShortName">
->;
-
-const defaultFlags: Flags = {
-    includeMetadataCodes: false,
-    useCodesForMetadata: false,
-    orgUnitShortName: false,
-};
-
-const metadataLanguage = "en";
-
 export function RegenerateMetadataDialog(props: RegenerateMetadataDialogProps): React.ReactElement {
     const { title, settings, onClose } = props;
-    const { api, compositionRoot } = useAppContext();
-    const snackbar = useSnackbar();
-    const loading = useLoading();
     const classes = useStyles();
 
-    const [resolution, setResolution] = useState<ResolutionState>({ type: "empty" });
-    const [flags, setFlags] = useState<Flags>(defaultFlags);
-    const [isRunning, setIsRunning] = useState(false);
-
-    const translations = useMemo(getTranslations, []);
-
-    const onDrop = useCallback(
-        async (files: File[]) => {
-            const file = files[0];
-
-            // Reason: react-dropzone passes an empty list when the dropped file fails the mime-type filter.
-            if (!file) {
-                setResolution({ type: "error", message: i18n.t("Only .xlsx and .xlsm template files are accepted") });
-                setFlags(defaultFlags);
-                return;
-            }
-
-            setResolution({ type: "loading" });
-
-            try {
-                const { template, dataForm } = await compositionRoot.templates.resolveFromFile(file);
-                setResolution({ type: "resolved", resolved: { file, template, dataForm } });
-                setFlags({ ...defaultFlags, includeMetadataCodes: template.includeMetadataCodes ?? false });
-            } catch (error: unknown) {
-                console.error(error);
-                setResolution({ type: "error", message: getErrorMessage(error) });
-                setFlags(defaultFlags);
-            }
-        },
-        [compositionRoot]
-    );
-
-    const setFlag = useCallback(
-        (flag: keyof Flags) => (_event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-            setFlags(flags => ({ ...flags, [flag]: checked }));
-        },
-        []
-    );
-
-    const regenerate = useCallback(async () => {
-        if (resolution.type !== "resolved") return;
-        const { file, dataForm } = resolution.resolved;
-
-        const extension = getExtensionFile(file.name);
-        const mimeType = extension ? MIME_TYPES_BY_EXTENSION[extension] : undefined;
-        if (!extension || !mimeType) {
-            snackbar.error(i18n.t("Unsupported file extension for template"));
-            return;
-        }
-
-        setIsRunning(true);
-        loading.show(true, i18n.t("Regenerating metadata..."));
-
-        try {
-            const fileContents = await toBase64(file);
-            const contents = await compositionRoot.templates.regenerateMetadata(api, {
-                type: dataForm.type,
-                id: dataForm.id,
-                fileContents,
-                settings,
-                language: metadataLanguage,
-                ...flags,
-            });
-
-            downloadFile({
-                filename: `${removeExtension(file.name)}-regenerated.${extension}`,
-                data: getBlobFromBase64(contents),
-                mimeType,
-            });
-
-            snackbar.success(i18n.t("Metadata regenerated"));
-            loading.hide();
-            setIsRunning(false);
-            onClose();
-        } catch (error: unknown) {
-            // Reason: stay open on failure so the message stays readable and the resolved file can be retried.
-            console.error(error);
-            snackbar.error(getErrorMessage(error));
-            loading.hide();
-            setIsRunning(false);
-        }
-    }, [api, compositionRoot, flags, loading, onClose, resolution, settings, snackbar]);
-
-    // Reason: ConfirmationDialog has no disable-cancel prop, and backdrop clicks and Escape reach onCancel as well.
-    const cancel = useCallback(() => {
-        if (isRunning) return;
-        onClose();
-    }, [isRunning, onClose]);
-
-    const droppedFileName = resolution.type === "resolved" ? resolution.resolved.file.name : undefined;
+    const {
+        resolution,
+        flags,
+        isRunning,
+        translations,
+        droppedFileName,
+        onDrop,
+        setFlag,
+        regenerate,
+        cancel,
+    } = useRegenerateMetadata({ settings, onClose });
 
     return (
         <ConfirmationDialog
@@ -217,15 +101,6 @@ export function RegenerateMetadataDialog(props: RegenerateMetadataDialogProps): 
             </p>
         </ConfirmationDialog>
     );
-}
-
-function getErrorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
-}
-
-function removeExtension(fileName: string): string {
-    const lastDotIndex = fileName.lastIndexOf(".");
-    return lastDotIndex === -1 ? fileName : fileName.slice(0, lastDotIndex);
 }
 
 const useStyles = makeStyles({

--- a/src/webapp/components/settings/RegenerateMetadataDialog.tsx
+++ b/src/webapp/components/settings/RegenerateMetadataDialog.tsx
@@ -1,0 +1,234 @@
+import { ConfirmationDialog, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { Checkbox, CircularProgress, FormControlLabel, FormGroup, makeStyles } from "@material-ui/core";
+import React, { useCallback, useMemo, useState } from "react";
+import { DataForm, getTranslations } from "../../../domain/entities/DataForm";
+import { Template } from "../../../domain/entities/Template";
+import { RegenerateTemplateMetadataOptions } from "../../../domain/usecases/RegenerateTemplateMetadataUseCase";
+import {
+    getBlobFromBase64,
+    getExtensionFile,
+    MIME_TYPES_BY_EXTENSION,
+    toBase64,
+    xlsxMimeTypes,
+} from "../../../utils/files";
+import i18n from "../../../utils/i18n";
+import { useAppContext } from "../../contexts/app-context";
+import { TemplateDropzone } from "../dropzone/TemplateDropzone";
+import Settings from "../../logic/settings";
+import { downloadFile } from "../../utils/download";
+
+export type RegenerateMetadataDialogProps = {
+    title: string;
+    settings: Settings;
+    onClose: () => void;
+};
+
+type ResolvedTemplate = {
+    file: File;
+    template: Template;
+    dataForm: DataForm;
+};
+
+type ResolutionState =
+    | { type: "empty" }
+    | { type: "loading" }
+    | { type: "resolved"; resolved: ResolvedTemplate }
+    | { type: "error"; message: string };
+
+type Flags = Readonly<
+    Pick<RegenerateTemplateMetadataOptions, "includeMetadataCodes" | "useCodesForMetadata" | "orgUnitShortName">
+>;
+
+const defaultFlags: Flags = {
+    includeMetadataCodes: false,
+    useCodesForMetadata: false,
+    orgUnitShortName: false,
+};
+
+const metadataLanguage = "en";
+
+export function RegenerateMetadataDialog(props: RegenerateMetadataDialogProps): React.ReactElement {
+    const { title, settings, onClose } = props;
+    const { api, compositionRoot } = useAppContext();
+    const snackbar = useSnackbar();
+    const loading = useLoading();
+    const classes = useStyles();
+
+    const [resolution, setResolution] = useState<ResolutionState>({ type: "empty" });
+    const [flags, setFlags] = useState<Flags>(defaultFlags);
+    const [isRunning, setIsRunning] = useState(false);
+
+    const translations = useMemo(getTranslations, []);
+
+    const onDrop = useCallback(
+        async (files: File[]) => {
+            const file = files[0];
+
+            // Reason: react-dropzone passes an empty list when the dropped file fails the mime-type filter.
+            if (!file) {
+                setResolution({ type: "error", message: i18n.t("Only .xlsx and .xlsm template files are accepted") });
+                setFlags(defaultFlags);
+                return;
+            }
+
+            setResolution({ type: "loading" });
+
+            try {
+                const { template, dataForm } = await compositionRoot.templates.resolveFromFile(file);
+                setResolution({ type: "resolved", resolved: { file, template, dataForm } });
+                setFlags({ ...defaultFlags, includeMetadataCodes: template.includeMetadataCodes ?? false });
+            } catch (error: unknown) {
+                console.error(error);
+                setResolution({ type: "error", message: getErrorMessage(error) });
+                setFlags(defaultFlags);
+            }
+        },
+        [compositionRoot]
+    );
+
+    const setFlag = useCallback(
+        (flag: keyof Flags) => (_event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
+            setFlags(flags => ({ ...flags, [flag]: checked }));
+        },
+        []
+    );
+
+    const regenerate = useCallback(async () => {
+        if (resolution.type !== "resolved") return;
+        const { file, dataForm } = resolution.resolved;
+
+        const extension = getExtensionFile(file.name);
+        const mimeType = extension ? MIME_TYPES_BY_EXTENSION[extension] : undefined;
+        if (!extension || !mimeType) {
+            snackbar.error(i18n.t("Unsupported file extension for template"));
+            return;
+        }
+
+        setIsRunning(true);
+        loading.show(true, i18n.t("Regenerating metadata..."));
+
+        try {
+            const fileContents = await toBase64(file);
+            const contents = await compositionRoot.templates.regenerateMetadata(api, {
+                type: dataForm.type,
+                id: dataForm.id,
+                fileContents,
+                settings,
+                language: metadataLanguage,
+                ...flags,
+            });
+
+            downloadFile({
+                filename: `${removeExtension(file.name)}-regenerated.${extension}`,
+                data: getBlobFromBase64(contents),
+                mimeType,
+            });
+
+            snackbar.success(i18n.t("Metadata regenerated"));
+            loading.hide();
+            setIsRunning(false);
+            onClose();
+        } catch (error: unknown) {
+            // Reason: stay open on failure so the message stays readable and the resolved file can be retried.
+            console.error(error);
+            snackbar.error(getErrorMessage(error));
+            loading.hide();
+            setIsRunning(false);
+        }
+    }, [api, compositionRoot, flags, loading, onClose, resolution, settings, snackbar]);
+
+    // Reason: ConfirmationDialog has no disable-cancel prop, and backdrop clicks and Escape reach onCancel as well.
+    const cancel = useCallback(() => {
+        if (isRunning) return;
+        onClose();
+    }, [isRunning, onClose]);
+
+    const droppedFileName = resolution.type === "resolved" ? resolution.resolved.file.name : undefined;
+
+    return (
+        <ConfirmationDialog
+            isOpen={true}
+            title={title}
+            maxWidth="md"
+            fullWidth={true}
+            onSave={regenerate}
+            onCancel={cancel}
+            saveText={i18n.t("Regenerate")}
+            cancelText={i18n.t("Close")}
+            disableSave={resolution.type !== "resolved" || isRunning}
+        >
+            <TemplateDropzone
+                accept={xlsxMimeTypes}
+                placeholder={i18n.t("Drag and drop the template file to regenerate")}
+                selectedFileName={droppedFileName}
+                onDrop={onDrop}
+                disabled={isRunning || resolution.type === "loading"}
+            />
+
+            {resolution.type === "loading" && <CircularProgress size={20} />}
+
+            {resolution.type === "error" && <p className={classes.error}>{resolution.message}</p>}
+
+            {resolution.type === "resolved" && (
+                <React.Fragment>
+                    <p>
+                        {i18n.t("Template")}: {resolution.resolved.template.name}
+                    </p>
+                    <p>
+                        {i18n.t("Data Form")}: {resolution.resolved.dataForm.name} ({resolution.resolved.dataForm.id})
+                    </p>
+                    <p>
+                        {i18n.t("Data Form Type")}: {translations.dataFormTypes[resolution.resolved.dataForm.type]}
+                    </p>
+
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={flags.includeMetadataCodes}
+                                    onChange={setFlag("includeMetadataCodes")}
+                                />
+                            }
+                            label={i18n.t("Include the Code column in the Metadata sheet")}
+                        />
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={flags.useCodesForMetadata}
+                                    onChange={setFlag("useCodesForMetadata")}
+                                />
+                            }
+                            label={i18n.t("Use codes instead of names for metadata items")}
+                        />
+                        <FormControlLabel
+                            control={
+                                <Checkbox checked={flags.orgUnitShortName} onChange={setFlag("orgUnitShortName")} />
+                            }
+                            label={i18n.t("Use the short name of organisation units")}
+                        />
+                    </FormGroup>
+                </React.Fragment>
+            )}
+
+            <p className={classes.note}>
+                {i18n.t(
+                    "The Metadata sheet will be re-protected with the standard Bulk Load sheet password. All other sheets and the macros are left untouched."
+                )}
+            </p>
+        </ConfirmationDialog>
+    );
+}
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function removeExtension(fileName: string): string {
+    const lastDotIndex = fileName.lastIndexOf(".");
+    return lastDotIndex === -1 ? fileName : fileName.slice(0, lastDotIndex);
+}
+
+const useStyles = makeStyles({
+    error: { color: "#f4231f" },
+    note: { color: "#707070", fontStyle: "italic" },
+});

--- a/src/webapp/components/settings/SettingsFields.tsx
+++ b/src/webapp/components/settings/SettingsFields.tsx
@@ -21,10 +21,8 @@ import { DataFormTemplateAssignDialog } from "./DataFormTemplateAssignDialog";
 import { PermissionsDialog } from "./PermissionsDialog";
 import { ProgramStageFilterDialog } from "./ProgramStageFilterDialog";
 import { TemplatesDialog } from "./TemplatesDialog";
-import { MaintenanceItem } from "./MaintenanceItem";
+import { MaintenanceSection } from "./MaintenanceSection";
 import { RouteComponentProps } from "../../pages/Router";
-import { useMaintenanceCleanup } from "../../hooks/useMaintenanceCleanup";
-import { useAppContext } from "../../contexts/app-context";
 
 type CustomTemplatesProps = Pick<RouteComponentProps, "customTemplates" | "setCustomTemplates">;
 
@@ -36,23 +34,6 @@ export interface SettingsFieldsProps {
 export default function SettingsFields(props: SettingsFieldsProps & CustomTemplatesProps) {
     const { settings, onChange, customTemplates, setCustomTemplates } = props;
     const classes = useStyles();
-    const { compositionRoot } = useAppContext();
-
-    const uploadsMaintenance = useMaintenanceCleanup({
-        cleanupAction: async (cutoffDate: Date) => {
-            await compositionRoot.history.cleanupDocuments(cutoffDate, settings.currentUser);
-        },
-        successMessage: i18n.t("File cleanup completed successfully"),
-        errorMessage: i18n.t("An error occurred during file cleanup"),
-    });
-
-    const historyMaintenance = useMaintenanceCleanup({
-        cleanupAction: async (cutoffDate: Date) => {
-            await compositionRoot.history.cleanup(cutoffDate, settings.currentUser);
-        },
-        successMessage: i18n.t("History cleanup completed successfully"),
-        errorMessage: i18n.t("An error occurred during history cleanup"),
-    });
 
     const [permissionsType, setPermissionsType] = useState<PermissionSetting | null>(null);
     const [isExclusionDialogVisible, showExclusionDialog] = useState<boolean>(false);
@@ -437,47 +418,7 @@ export default function SettingsFields(props: SettingsFieldsProps & CustomTempla
                 </ListItem>
             </FormGroup>
 
-            <h3 className={classes.title}>{i18n.t("Maintenance")}</h3>
-
-            <MaintenanceItem
-                config={{
-                    icon: "description",
-                    primaryText: i18n.t("File cleanup"),
-                    secondaryText: i18n.t(
-                        "Remove files older than the selected period. History entries will be kept but the files will be unaccessible"
-                    ),
-                    loadingText: i18n.t("Cleaning up files..."),
-                    confirmationTitle: i18n.t("Confirm File Cleanup"),
-                    confirmationDescription: i18n.t(
-                        "Are you sure you want to remove all files older than the selected period? This action cannot be undone. History entries will be kept but the files will be inaccessible."
-                    ),
-                    periodInputLabel: i18n.t("Remove files older than"),
-                    finalConfirmationTitle: i18n.t("Confirm File Cleanup"),
-                    operationName: i18n.t("File cleanup"),
-                    saveText: i18n.t("Clean up files"),
-                }}
-                maintenance={uploadsMaintenance}
-            />
-
-            <MaintenanceItem
-                config={{
-                    icon: "history",
-                    primaryText: i18n.t("History cleanup"),
-                    secondaryText: i18n.t(
-                        "Remove history entries and their documents older than the selected period. This action cannot be undone"
-                    ),
-                    loadingText: i18n.t("Cleaning up history..."),
-                    confirmationTitle: i18n.t("Confirm History Cleanup"),
-                    confirmationDescription: i18n.t(
-                        "Are you sure you want to remove all history entries and their documents older than the selected period? This action cannot be undone."
-                    ),
-                    periodInputLabel: i18n.t("Remove history entries older than"),
-                    finalConfirmationTitle: i18n.t("Confirm History Cleanup"),
-                    operationName: i18n.t("History cleanup"),
-                    saveText: i18n.t("Clean up history"),
-                }}
-                maintenance={historyMaintenance}
-            />
+            <MaintenanceSection settings={settings} />
         </React.Fragment>
     );
 }

--- a/src/webapp/hooks/useRegenerateMetadata.ts
+++ b/src/webapp/hooks/useRegenerateMetadata.ts
@@ -1,0 +1,170 @@
+import { useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import React, { useCallback, useMemo, useState } from "react";
+import { DataForm, getTranslations } from "../../domain/entities/DataForm";
+import { Template } from "../../domain/entities/Template";
+import { RegenerateTemplateMetadataOptions } from "../../domain/usecases/RegenerateTemplateMetadataUseCase";
+import { getBlobFromBase64, getExtensionFile, MIME_TYPES_BY_EXTENSION, toBase64 } from "../../utils/files";
+import i18n from "../../utils/i18n";
+import { useAppContext } from "../contexts/app-context";
+import Settings from "../logic/settings";
+import { downloadFile } from "../utils/download";
+
+export type ResolvedTemplate = {
+    file: File;
+    template: Template;
+    dataForm: DataForm;
+};
+
+export type ResolutionState =
+    | { type: "empty" }
+    | { type: "loading" }
+    | { type: "resolved"; resolved: ResolvedTemplate }
+    | { type: "error"; message: string };
+
+export type Flags = Readonly<
+    Pick<RegenerateTemplateMetadataOptions, "includeMetadataCodes" | "useCodesForMetadata" | "orgUnitShortName">
+>;
+
+const defaultFlags: Flags = {
+    includeMetadataCodes: false,
+    useCodesForMetadata: false,
+    orgUnitShortName: false,
+};
+
+const metadataLanguage = "en";
+
+export type UseRegenerateMetadataOptions = {
+    settings: Settings;
+    onClose: () => void;
+};
+
+export type UseRegenerateMetadataState = {
+    resolution: ResolutionState;
+    flags: Flags;
+    isRunning: boolean;
+    translations: ReturnType<typeof getTranslations>;
+    droppedFileName: string | undefined;
+    onDrop: (files: File[]) => Promise<void>;
+    setFlag: (flag: keyof Flags) => (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
+    regenerate: () => Promise<void>;
+    cancel: () => void;
+};
+
+export function useRegenerateMetadata(options: UseRegenerateMetadataOptions): UseRegenerateMetadataState {
+    const { settings, onClose } = options;
+    const { api, compositionRoot } = useAppContext();
+    const snackbar = useSnackbar();
+    const loading = useLoading();
+
+    const [resolution, setResolution] = useState<ResolutionState>({ type: "empty" });
+    const [flags, setFlags] = useState<Flags>(defaultFlags);
+    const [isRunning, setIsRunning] = useState(false);
+
+    const translations = useMemo(getTranslations, []);
+
+    const onDrop = useCallback(
+        async (files: File[]) => {
+            const file = files[0];
+
+            // Reason: react-dropzone passes an empty list when the dropped file fails the mime-type filter.
+            if (!file) {
+                setResolution({ type: "error", message: i18n.t("Only .xlsx and .xlsm template files are accepted") });
+                setFlags(defaultFlags);
+                return;
+            }
+
+            setResolution({ type: "loading" });
+
+            try {
+                const { template, dataForm } = await compositionRoot.templates.resolveFromFile(file);
+                setResolution({ type: "resolved", resolved: { file, template, dataForm } });
+                setFlags({ ...defaultFlags, includeMetadataCodes: template.includeMetadataCodes ?? false });
+            } catch (error: unknown) {
+                console.error(error);
+                setResolution({ type: "error", message: getErrorMessage(error) });
+                setFlags(defaultFlags);
+            }
+        },
+        [compositionRoot]
+    );
+
+    const setFlag = useCallback(
+        (flag: keyof Flags) => (_event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
+            setFlags(flags => ({ ...flags, [flag]: checked }));
+        },
+        []
+    );
+
+    const regenerate = useCallback(async () => {
+        if (resolution.type !== "resolved") return;
+        const { file, dataForm } = resolution.resolved;
+
+        const extension = getExtensionFile(file.name);
+        const mimeType = extension ? MIME_TYPES_BY_EXTENSION[extension] : undefined;
+        if (!extension || !mimeType) {
+            snackbar.error(i18n.t("Unsupported file extension for template"));
+            return;
+        }
+
+        setIsRunning(true);
+        loading.show(true, i18n.t("Regenerating metadata..."));
+
+        try {
+            const fileContents = await toBase64(file);
+            const contents = await compositionRoot.templates.regenerateMetadata(api, {
+                type: dataForm.type,
+                id: dataForm.id,
+                fileContents,
+                settings,
+                language: metadataLanguage,
+                ...flags,
+            });
+
+            downloadFile({
+                filename: `${removeExtension(file.name)}-regenerated.${extension}`,
+                data: getBlobFromBase64(contents),
+                mimeType,
+            });
+
+            snackbar.success(i18n.t("Metadata regenerated"));
+            loading.hide();
+            setIsRunning(false);
+            onClose();
+        } catch (error: unknown) {
+            // Reason: stay open on failure so the message stays readable and the resolved file can be retried.
+            console.error(error);
+            snackbar.error(getErrorMessage(error));
+            loading.hide();
+            setIsRunning(false);
+        }
+    }, [api, compositionRoot, flags, loading, onClose, resolution, settings, snackbar]);
+
+    // Reason: ConfirmationDialog has no disable-cancel prop, and backdrop clicks and Escape reach onCancel as well.
+    const cancel = useCallback(() => {
+        if (isRunning) return;
+        onClose();
+    }, [isRunning, onClose]);
+
+    const droppedFileName = resolution.type === "resolved" ? resolution.resolved.file.name : undefined;
+
+    return {
+        resolution,
+        flags,
+        isRunning,
+        translations,
+        droppedFileName,
+        onDrop,
+        setFlag,
+        regenerate,
+        cancel,
+    };
+}
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function removeExtension(fileName: string): string {
+    const lastDotIndex = fileName.lastIndexOf(".");
+    return lastDotIndex === -1 ? fileName : fileName.slice(0, lastDotIndex);
+}

--- a/src/webapp/logic/Workbook.ts
+++ b/src/webapp/logic/Workbook.ts
@@ -34,6 +34,18 @@ export class Workbook {
         return new Workbook(workbook);
     }
 
+    // Loads from a (raw or data-URI) base64 string without the browser-only fetch/File path,
+    // so it works in Node (scripts) and the browser alike.
+    static async fromBase64Data(base64: string) {
+        const clean = base64.replace(/^data:[^,]*,/, "");
+        const bytes =
+            typeof Buffer !== "undefined"
+                ? new Uint8Array(Buffer.from(clean, "base64"))
+                : Uint8Array.from(atob(clean), character => character.charCodeAt(0));
+        const workbook = await XlsxPopulate.fromDataAsync(bytes);
+        return new Workbook(workbook);
+    }
+
     static getExcelAlpha(n: number): string {
         if (n === 0) return "";
         const columnsRange = 26;
@@ -70,6 +82,11 @@ export class Workbook {
         return this.xworkbook.outputAsync({ type: "blob" });
     }
 
+    // Cross-environment output (works in both browser and Node, unlike the "blob" type).
+    writeToBase64(): Promise<string> {
+        return this.xworkbook.outputAsync({ type: "base64" });
+    }
+
     get definedNameCollection() {
         return {
             addDefinedName: (options: { name: string; refFormula: string }) => {
@@ -88,6 +105,14 @@ export class Sheet {
 
     get name() {
         return this.xsheet.name();
+    }
+
+    // Clears the sheet's used range in place (values), preserving the sheet identity
+    // (codeName / VBA binding) — deleting the sheet instead would orphan its VBA module.
+    clear() {
+        const usedRange = this.xsheet.usedRange();
+        if (usedRange) usedRange.clear();
+        return this;
     }
 
     row(rowNumber: number) {

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -169,7 +169,7 @@ export class SheetBuilder {
         const workbook = await Workbook.fromBase64Data(fileContents);
         const metadataSheet = workbook.addWorksheet("Metadata", protectedSheet);
         metadataSheet.clear();
-        this.fillMetadataSheet(metadataSheet, this.builder.orgUnitShortName || false);
+        this.fillMetadataSheet(metadataSheet, this.builder.orgUnitShortName);
         return workbook;
     }
 
@@ -714,6 +714,11 @@ export class SheetBuilder {
         const { workbook } = metadataSheet;
         const { elementMetadata: metadata, organisationUnits } = this.builder;
 
+        const codeColumn = 8;
+        const writeCode = (rowId: number, code: string | undefined) => {
+            if (this.builder.includeMetadataCodes) metadataSheet.cell(rowId, codeColumn).string(code ?? "");
+        };
+
         // Freeze and format column titles
         metadataSheet.row(2).freeze();
         metadataSheet.column(1).setWidth(30);
@@ -751,7 +756,7 @@ export class SheetBuilder {
             .style(baseStyle);
         if (this.builder.includeMetadataCodes) {
             metadataSheet
-                .cell(1, 8, 2, 8, true)
+                .cell(1, codeColumn, 2, codeColumn, true)
                 .string(i18n.t("Code", { lng: this.builder.language }))
                 .style(baseStyle);
         }
@@ -782,9 +787,7 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 5).string(optionSetName ?? "");
             metadataSheet.cell(rowId, 6).string(options ?? "");
             metadataSheet.cell(rowId, 7).string(`${item.version ?? ""}`);
-            if (this.builder.includeMetadataCodes) {
-                metadataSheet.cell(rowId, 8).string(item.code ?? "");
-            }
+            writeCode(rowId, item.code);
 
             if (name !== undefined) {
                 workbook.definedNameCollection.addDefinedName({
@@ -801,9 +804,7 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 1).string(orgUnit.id !== undefined ? orgUnit.id : "");
             metadataSheet.cell(rowId, 2).string("organisationUnit");
             metadataSheet.cell(rowId, 3).string(name ?? "");
-            if (this.builder.includeMetadataCodes) {
-                metadataSheet.cell(rowId, 8).string(orgUnit.code ?? "");
-            }
+            writeCode(rowId, orgUnit.code);
 
             if (name !== undefined)
                 workbook.definedNameCollection.addDefinedName({

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -55,6 +55,7 @@ export interface SheetBuilderParams {
     useCodesForMetadata: boolean;
     orgUnitShortName: boolean;
     maxTeiRows?: number;
+    includeMetadataCodes?: boolean;
 }
 
 export class SheetBuilder {
@@ -736,6 +737,12 @@ export class SheetBuilder {
             .cell(1, 7, 2, 7, true)
             .string(i18n.t("Metadata version", { lng: this.builder.language }))
             .style(baseStyle);
+        if (this.builder.includeMetadataCodes) {
+            metadataSheet
+                .cell(1, 8, 2, 8, true)
+                .string(i18n.t("Code", { lng: this.builder.language }))
+                .style(baseStyle);
+        }
 
         let rowId = 3;
 
@@ -763,6 +770,9 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 5).string(optionSetName ?? "");
             metadataSheet.cell(rowId, 6).string(options ?? "");
             metadataSheet.cell(rowId, 7).string(`${item.version ?? ""}`);
+            if (this.builder.includeMetadataCodes) {
+                metadataSheet.cell(rowId, 8).string(item.code ?? "");
+            }
 
             if (name !== undefined) {
                 workbook.definedNameCollection.addDefinedName({

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -42,6 +42,7 @@ export interface SheetBuilderParams {
         id: string;
         displayName: string;
         translations: any;
+        code?: string;
     }[];
     rawMetadata: any;
     startDate?: Moment;
@@ -789,6 +790,9 @@ export class SheetBuilder {
             metadataSheet.cell(rowId, 1).string(orgUnit.id !== undefined ? orgUnit.id : "");
             metadataSheet.cell(rowId, 2).string("organisationUnit");
             metadataSheet.cell(rowId, 3).string(name ?? "");
+            if (this.builder.includeMetadataCodes) {
+                metadataSheet.cell(rowId, 8).string(orgUnit.code ?? "");
+            }
 
             if (name !== undefined)
                 workbook.definedNameCollection.addDefinedName({

--- a/src/webapp/logic/sheetBuilder.ts
+++ b/src/webapp/logic/sheetBuilder.ts
@@ -162,6 +162,17 @@ export class SheetBuilder {
         return workbook;
     }
 
+    // Regenerates ONLY the Metadata sheet of an existing custom template, leaving every
+    // other sheet (custom form, dropdowns, VBA) untouched. The sheet is cleared and refilled
+    // in place — not deleted — so its codeName/VBA binding survives.
+    public async generateMetadataOnly(fileContents: string): Promise<Workbook> {
+        const workbook = await Workbook.fromBase64Data(fileContents);
+        const metadataSheet = workbook.addWorksheet("Metadata", protectedSheet);
+        metadataSheet.clear();
+        this.fillMetadataSheet(metadataSheet, this.builder.orgUnitShortName || false);
+        return workbook;
+    }
+
     private fillRelationshipSheets(relationshipsSheets: Array<[relationshipType: any, sheet: Sheet]>) {
         const { element: program } = this.builder;
 

--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -18,12 +18,7 @@ import { orgUnitListParams } from "../../utils/template";
 import { RouteComponentProps } from "../Router";
 import { TemplateDataPackage, templateToDataPackage } from "../../../domain/entities/Template";
 
-const importAcceptedMimeTypes = [
-    "application/zip",
-    "application/x-zip-compressed",
-    xlsxMimeType,
-    xlsxMacroMimeType,
-];
+const importAcceptedMimeTypes = ["application/zip", "application/x-zip-compressed", xlsxMimeType, xlsxMacroMimeType];
 
 interface ImportState {
     dataForm: DataForm;
@@ -427,4 +422,3 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
         </React.Fragment>
     );
 }
-

--- a/src/webapp/pages/import-template/ImportTemplatePage.tsx
+++ b/src/webapp/pages/import-template/ImportTemplatePage.tsx
@@ -1,16 +1,15 @@
 import { OrgUnitsSelector, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
-import { Button, Checkbox, FormControlLabel, makeStyles } from "@material-ui/core";
-import CloudDoneIcon from "@material-ui/icons/CloudDone";
-import CloudUploadIcon from "@material-ui/icons/CloudUpload";
+import { Button, Checkbox, FormControlLabel } from "@material-ui/core";
 import { saveAs } from "file-saver";
 import _ from "lodash";
 import moment from "moment";
 import React, { useCallback, useEffect, useState } from "react";
-import Dropzone from "react-dropzone";
 import { DataForm, DataFormType } from "../../../domain/entities/DataForm";
 import { SynchronizationResult } from "../../../domain/entities/SynchronizationResult";
 import { ImportTemplateUseCaseParams } from "../../../domain/usecases/ImportTemplateUseCase";
+import { xlsxMacroMimeType, xlsxMimeType } from "../../../utils/files";
 import i18n from "../../../utils/i18n";
+import { TemplateDropzone } from "../../components/dropzone/TemplateDropzone";
 import ModalDialog, { ModalDialogProps } from "../../components/modal-dialog/ModalDialog";
 import { ImportResultBadge } from "../../components/import-result-badge/ImportResultBadge";
 import SyncSummaryDialog from "../../components/sync-summary/SyncSummaryDialog";
@@ -18,6 +17,13 @@ import { useAppContext } from "../../contexts/app-context";
 import { orgUnitListParams } from "../../utils/template";
 import { RouteComponentProps } from "../Router";
 import { TemplateDataPackage, templateToDataPackage } from "../../../domain/entities/Template";
+
+const importAcceptedMimeTypes = [
+    "application/zip",
+    "application/x-zip-compressed",
+    xlsxMimeType,
+    xlsxMacroMimeType,
+];
 
 interface ImportState {
     dataForm: DataForm;
@@ -33,7 +39,6 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
     const { api, compositionRoot } = useAppContext();
     const loading = useLoading();
     const snackbar = useSnackbar();
-    const classes = useStyles();
 
     const [orgUnitTreeRootIds, setOrgUnitTreeRootIds] = useState<string[]>([]);
     const [selectedOrgUnits, setSelectedOrgUnits] = useState<string[]>([]);
@@ -311,44 +316,12 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
 
             <h3>{i18n.t("Bulk data import")}</h3>
 
-            <Dropzone
-                accept={[
-                    "application/zip",
-                    "application/x-zip-compressed",
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    "application/vnd.ms-excel.sheet.macroEnabled.12",
-                ]}
+            <TemplateDropzone
+                accept={importAcceptedMimeTypes}
+                placeholder={i18n.t("Drag and drop file to import")}
+                selectedFileName={importState?.file.name}
                 onDrop={onDrop}
-                multiple={false}
-            >
-                {({ getRootProps, getInputProps, isDragActive, isDragAccept }) => (
-                    <section className={classes.dropzoneSection}>
-                        <div
-                            {...getRootProps({
-                                className: isDragActive
-                                    ? `${classes.stripes} ${
-                                          isDragAccept ? classes.acceptStripes : classes.rejectStripes
-                                      }`
-                                    : classes.dropzone,
-                            })}
-                        >
-                            <input {...getInputProps()} />
-                            <div className={classes.dropzoneTextStyle} hidden={importState?.file !== undefined}>
-                                <p className={classes.dropzoneParagraph}>{i18n.t("Drag and drop file to import")}</p>
-                                <br />
-                                <CloudUploadIcon className={classes.uploadIconSize} />
-                            </div>
-                            <div className={classes.dropzoneTextStyle} hidden={importState?.file === undefined}>
-                                {importState?.file !== undefined && (
-                                    <p className={classes.dropzoneParagraph}>{importState?.file.name}</p>
-                                )}
-                                <br />
-                                <CloudDoneIcon className={classes.uploadIconSize} />
-                            </div>
-                        </div>
-                    </section>
-                )}
-            </Dropzone>
+            />
 
             {syncResults && <ImportResultBadge results={syncResults} onClick={openSyncDialog} />}
 
@@ -455,47 +428,3 @@ export default function ImportTemplatePage({ settings }: RouteComponentProps) {
     );
 }
 
-const useStyles = makeStyles({
-    dropzoneTextStyle: { textAlign: "center", top: "15%", position: "relative" },
-    dropzoneParagraph: { fontSize: 20 },
-    uploadIconSize: { width: 50, height: 50, color: "#909090" },
-    dropzone: {
-        position: "relative",
-        width: "100%",
-        height: 270,
-        backgroundColor: "#f0f0f0",
-        border: "dashed",
-        borderColor: "#c8c8c8",
-        cursor: "pointer",
-    },
-    stripes: {
-        width: "100%",
-        height: 270,
-        cursor: "pointer",
-        border: "solid",
-        borderColor: "#c8c8c8",
-        "-webkit-animation": "progress 2s linear infinite !important",
-        "-moz-animation": "progress 2s linear infinite !important",
-        animation: "progress 2s linear infinite !important",
-        backgroundSize: "150% 100%",
-    },
-    acceptStripes: {
-        backgroundImage: `repeating-linear-gradient(
-            -45deg,
-            #f0f0f0,
-            #f0f0f0 25px,
-            #c8c8c8 25px,
-            #c8c8c8 50px
-        )`,
-    },
-    rejectStripes: {
-        backgroundImage: `repeating-linear-gradient(
-            -45deg,
-            #fc8785,
-            #fc8785 25px,
-            #f4231f 25px,
-            #f4231f 50px
-        )`,
-    },
-    dropzoneSection: { marginBottom: "1em" },
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,9 +4106,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eyeseetea/d2-api@npm:1.20.0":
-  version: 1.20.0
-  resolution: "@eyeseetea/d2-api@npm:1.20.0"
+"@eyeseetea/d2-api@npm:1.21.0":
+  version: 1.21.0
+  resolution: "@eyeseetea/d2-api@npm:1.21.0"
   dependencies:
     abort-controller: "npm:3.0.0"
     axios: "npm:1.6.4"
@@ -4119,8 +4119,7 @@ __metadata:
     iconv-lite: "npm:0.6.2"
     lodash: "npm:4.17.21"
     qs: "npm:6.9.7"
-    react: "npm:^16.12.0"
-  checksum: 10c0/611f6a927151a3c300dc526cb7376326ed9f536d6ca91aa6d9a6d506aff408daf0b36963db81628506383cff7d59c0df40a8fe7583db5a93c8bebde0a00fde26
+  checksum: 10c0/f70c2e34b7a284ccec23ea24869cc764b2607b09a55acdd1b8fea0a19337a729277f5a1a3fdd2cc4bf53539527ed5f04aaf32308d676f5f9cef5cce46ec1f2e4
   languageName: node
   linkType: hard
 
@@ -6421,7 +6420,7 @@ __metadata:
     "@dhis2/d2-ui-core": "npm:7.3.3"
     "@dhis2/ui-core": "npm:6.24.0"
     "@dhis2/ui-widgets": "npm:6.24.0"
-    "@eyeseetea/d2-api": "npm:1.20.0"
+    "@eyeseetea/d2-api": "npm:1.21.0"
     "@eyeseetea/d2-ui-components": "npm:2.12.0"
     "@eyeseetea/feedback-component": "npm:0.3.0"
     "@eyeseetea/xlsx-populate": "npm:4.3.2-beta.1"
@@ -12567,17 +12566,6 @@ __metadata:
     loose-envify: "npm:^1.1.0"
     object-assign: "npm:^4.1.1"
   checksum: 10c0/07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
-  languageName: node
-  linkType: hard
-
-"react@npm:^16.12.0":
-  version: 16.13.1
-  resolution: "react@npm:16.13.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    prop-types: "npm:^15.6.2"
-  checksum: 10c0/4d6ad44cd5c12511218ad179df94919b5c1c328d078160a9f39ae7d31738c427a9b6bbcf9fb4745f4c4f534ddab8529acc24e7cd9dce086c76e3478422256fb3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** #869dg8vj6
* **Depends on:** #408 - **required, must merge first** (see below)

### :memo: Implementation

- Add a **`regenerate-metadata`** use case + CLI script that refreshes **only** the Metadata sheet of an existing template from fresh DHIS2 metadata, leaving every other sheet (custom form, dropdowns, VBA) untouched.
- `SheetBuilder.generateMetadataOnly` clears and refills the Metadata sheet **in place** (not deleted) so the sheet's `codeName` / VBA binding survives.
- CLI flags: `--dhis2-url`, `--auth`, `--input`, `--output`, `--form-id`, `--form-type`, `--language`, plus the metadata-generation toggles `--include-codes`, `--use-codes`, `--org-unit-short-name` (all default off).
- `yarn regenerate-metadata` alias; README documentation.
- Bumps `@eyeseetea/d2-api` to `1.21.0`.

- Extracted MaintenanceSection from Settings page and added regenerate option there

### :fire: Notes for the reviewer


### :video_camera: Screenshots/Screen capture

For testing, i used 
[PHSM - Policy Tracker.xlsm](https://github.com/user-attachments/files/30490206/PHSM.-.Policy.Tracker.xlsm)
this file where these metadata rows are removed

<img width="1739" height="704" alt="image" src="https://github.com/user-attachments/assets/b1a28fca-a614-4381-b0b9-56a9e8c9b7d7" />


https://github.com/user-attachments/assets/bd160e39-062f-4745-ae59-78cffaa3a5bc




### :bookmark_tabs: Others