### PR TITLE
[FIX] download-template: query /organisationUnits instead of /metadata for v43

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,7 @@
 /** @format */
 
 module.exports = {
-    extends: [
-        "react-app",
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended",
-    ],
+    extends: ["react-app", "eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended"],
     parser: "@typescript-eslint/parser",
     rules: {
         "no-console": ["warn", { allow: ["debug", "warn", "error"] }],

--- a/src/domain/usecases/DownloadTemplateUseCase.ts
+++ b/src/domain/usecases/DownloadTemplateUseCase.ts
@@ -325,31 +325,24 @@ async function getElementMetadata({
     });
 
     // FIXME: This is needed for getting all possible org units for a program/dataSet
-    const requestOrgUnits =
+    const requestOrgUnits: Id[] =
         relationshipsOuFilter === "DESCENDANTS" || relationshipsOuFilter === "CHILDREN"
             ? elementMetadataMap.get(element.id)?.organisationUnits?.map(({ id }: { id: string }) => id) ?? orgUnitIds
             : orgUnitIds;
 
     const responses = await promiseMap(_.chunk(_.uniq(requestOrgUnits), 400), orgUnits =>
-        api
-            .get<{
-                organisationUnits: {
-                    id: string;
-                    displayShortName: string;
-                    displayName: string;
-                    code?: string;
-                    translations: unknown;
-                }[];
-            }>("/metadata", {
-                fields: "id,displayName,code,translations,displayShortName",
-                filter: `id:in:[${orgUnits}]`,
+        api.models.organisationUnits
+            .get({
+                paging: false,
+                fields: { id: true, displayName: true, code: true, translations: true, displayShortName: true },
+                filter: { id: { in: orgUnits } },
                 order: orgUnitShortName ? "displayShortName:asc" : "displayName:asc",
             })
             .getData()
     );
 
-    const organisationUnits = _.flatMap(responses, ({ organisationUnits }) =>
-        organisationUnits.map(orgUnit => ({
+    const organisationUnits = _.flatMap(responses, ({ objects }) =>
+        objects.map(orgUnit => ({
             type: "organisationUnits",
             ...orgUnit,
         }))

--- a/src/domain/usecases/utils/orgUnits.ts
+++ b/src/domain/usecases/utils/orgUnits.ts
@@ -11,8 +11,7 @@ export function getCaptureOrgUnitIdsForDataForm(
         .filter(dataFormOrgUnit =>
             userOrgUnits.some(
                 userOrgUnit =>
-                    dataFormOrgUnit.path === userOrgUnit.path ||
-                    dataFormOrgUnit.path.startsWith(`${userOrgUnit.path}/`)
+                    dataFormOrgUnit.path === userOrgUnit.path || dataFormOrgUnit.path.startsWith(`${userOrgUnit.path}/`)
             )
         )
         .map(orgUnit => orgUnit.id);


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes [#869djm0wn](https://app.clickup.com/t/4528615/869djm0wn)

### :memo: Implementation

#### Why the 400 happened

The request went to the wrong endpoint. On `/api/metadata`, un-prefixed `fields`, `filter` and `order` are **defaults applied to every exportable schema**, not to the type you care about. The v43 docs say it literally — *"Default order to apply to all  types"* — and the wording is identical in the 2.41 docs, so this call was always  incorrect. It was simply harmless before: `filter=id:in:[...]` matched nothing in the  other schemas, so they came back as empty arrays and only `organisationUnits` was  visible in the response.

#### Why it broke in v43 specifically

Comparing `JpaCriteriaQueryEngine.java` across the dhis2-core release branches:

  - **2.41 / 2.42** — ordering was a flat `root.get(property.getFieldName())` with no `display*` handling at all. Ordering by `displayName` never reached the database.
  - **2.43** — added `tryGetTranslatableOrder` / `handleDisplayProperty` (absent in both  earlier branches) to push translatable ordering down  into JPA.

The final fallback in `handleDisplayProperty` calls `getRegularOrder` **without checking that the entity actually maps the column**. `displayName` resolves to `name` and  `displayShortName` to `shortName`, so applying it across all schemas ends up calling `root.get("shortName")` on `OptionGroupSet` and `root.get("name")` on `ApiToken`, which don't map those columns. DHIS2's `Schema` claims the property exists; the Hibernate entity doesn't have it.

v43 also upgraded **Hibernate 5 → 6**, whose `AbstractManagedType.checkNotNull` throws where the old metamodel tolerated the mismatch. That's the top frame of the stack trace,  and the reason this surfaces as a 400 rather than being silently ignored.
                                                                                
- [DHIS2-21326](https://dhis2.atlassian.net/browse/DHIS2-21326) (OAuth2 Clients tab 400) → closed as duplicate of [DHIS2-21347](https://dhis2.atlassian.net/browse/DHIS2-21347): fixed per-entity
- [DHIS2-21374](https://dhis2.atlassian.net/browse/DHIS2-21374): general fix

### :fire: Notes for the reviewer

- download a template from a program

### :art: Screenshots

ERROR:

<img width="1863" height="963" alt="image" src="https://github.com/user-attachments/assets/e6f2c7b2-862c-4a04-8a58-56dc562786d0" />

FIXED:

<img width="1863" height="963" alt="image" src="https://github.com/user-attachments/assets/296f98cc-99ae-4550-be1b-5bf582234aaf" />


### :bookmark_tabs: Others
