### PR TITLE
fix: add missing lodash import in MSF module metadata repo

### DIFF
--- a/src/data/templates/nrc/MSFModuleMetadataD2Repository.ts
+++ b/src/data/templates/nrc/MSFModuleMetadataD2Repository.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { D2Api, MetadataPick } from "../../../types/d2-api";
 import { i18nShortCode, Id } from "../../../domain/entities/ReferenceObject";
 import { CategoryOptionCombo, MSFModuleMetadata } from "../../../domain/entities/templates/MSFModuleMetadata";


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/4528615/869cc53c7

### :memo: Implementation

- `MSFModuleMetadataD2Repository.getAllCategoryOptionCombos` called `_.chunk(...)` without importing `lodash` in that file, so the reference was unresolved.
- This existed since the MSF custom module was first added and was present through every release built with CRA/webpack (including the v3.32.0 build previously tested by the client). It only surfaced after the Vite/Rollup migration, which no longer resolves the stray reference by coincidence, throwing `ReferenceError: _ is not defined` and blocking the download of the MSF custom template.
- Added the missing `import _ from "lodash"`.

### :fire: Notes for the reviewer

- Reproduced on the OCBA staging instance (constant storage, "BulkLoadTemplate" custom template): confirmed the crash on an unpatched v3.35 build, then confirmed the fix resolves it on a rebuilt v3.35 with the import added.

### :video_camera: Screenshots/Screen capture

### :bookmark_tabs: Others